### PR TITLE
[MNT] Fix Codecov unknown status — upgrade action to v5 and add codecov.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,11 @@ jobs:
         run: uv run pytest tests/ --cov=src --cov-report=xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
+          fail_ci_if_error: true
 
       - name: Security scan
         run: uv run pip-audit

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ tokens/
 reports/*.html
 reports/*.xml
 reports/latest_*
+planning/
 
 # Jupyter Notebook checkpoints
 .ipynb_checkpoints

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 5%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
#### Reference Issues/PRs

No related issue. Changes are maintenance-only.

#### Type of change
- [x] Bug fix


#### What does this implement/fix? Explain your changes.

Codecov was reporting an "unknown" status on commits/PRs due to two issues:
- `codecov/codecov-action` was pinned to v4, which has deprecated uploader infrastructure causing silent upload failures
- No `codecov.yml` existed, so Codecov had no coverage targets to evaluate against

This PR upgrades the action to v5, adds `fail_ci_if_error: true` so upload failures surface as CI failures, and introduces a `codecov.yml` with `auto` targets for both project and patch coverage.


#### Does your contribution introduce a new dependency? If yes, which one?

No.


#### What should a reviewer concentrate their feedback on?

- The `codecov.yml` thresholds (`1%` project, `5%` patch) — adjust if stricter gates are preferred.


#### Did you add any tests for the change?

No — this is a CI/config-only change with no code logic to test.

---

#### PR checklist
- [x] The PR title starts with `[MNT]`
- [x] Tests added or updated for any changed behaviour — N/A
- [x] No secrets, credentials, or `.env` values committed
- [x] `pyproject.toml` updated if new dependencies were added — N/A