### PR TITLE
[MNT] Add Codecov test results upload and ignore generated report files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,13 @@ jobs:
         run: uv run ruff format --check .
 
       - name: Run tests with coverage
-        run: uv run pytest tests/ --cov=src --cov-report=xml
+        run: uv run pytest tests/ --cov=src --cov-report=xml --junit-xml=junit.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage
         uses: codecov/codecov-action@v5

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ tokens/
 reports/*.html
 reports/*.xml
 reports/latest_*
+coverage.xml
+junit.xml
+.coverage
 planning/
 
 # Jupyter Notebook checkpoints

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,13 @@ coverage:
         target: auto
         threshold: 5%
 
+github_checks:
+  annotations: true
+
+codecov:
+  notify:
+    after_n_builds: 1
+
 comment:
   layout: "reach,diff,flags,files"
   behavior: default


### PR DESCRIPTION
**Title:** `[MNT] Add Codecov test results upload and ignore generated report files`

---

#### Reference Issues/PRs

No related issue.

---

#### Type of change
- [x] Bug fix

---

#### What does this implement/fix? Explain your changes.

- Added `codecov/test-results-action@v1` step to CI to upload JUnit XML test results to Codecov, enabling the Test Analytics dashboard
- Added `--junit-xml=junit.xml` flag to the pytest command to generate the required JUnit report
- Added `coverage.xml`, `junit.xml`, and `.coverage` to `.gitignore` to prevent locally generated report artifacts from being committed

---

#### Does your contribution introduce a new dependency? If yes, which one?

No.

---

#### What should a reviewer concentrate their feedback on?

- The `if: ${{ !cancelled() }}` condition on the test results upload — this ensures results are uploaded even on test failure, which is intentional.

---

#### Did you add any tests for the change?

No — CI/config-only change.

---

#### PR checklist
- [x] The PR title starts with `[MNT]`
- [x] Tests added or updated for any changed behaviour — N/A
- [x] No secrets, credentials, or `.env` values committed
- [x] `pyproject.toml` updated if new dependencies were added — N/A