### PR TITLE
[DOC] Add CHANGELOG.md with v0.1.0 release history

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,6 @@
+#### Title
+<!-- Start with a tag: [ENH], [MNT], [DOC], [BUG], [SEC], or [BREAKING] — e.g. "[ENH] Add spam detector" -->
+
 #### Reference Issues/PRs
 <!--
 Example: Fixes #1234. See also #5678.
@@ -5,7 +8,7 @@ Example: Fixes #1234. See also #5678.
 Please use keywords (e.g., Fixes) to create link to the issues or pull requests
 you resolved, so that they will automatically be closed when your pull request
 is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
-If no issue exists, you can open one here: https://github.com/ksharma6/inbox_zero/issues
+If no issue exists, you can open one here: https://github.com/ksharma6/Inbox0/issues
 -->
 
 #### Type of change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed Codecov unknown status — upgraded action to v5 and added `codecov.yml` ([#53](https://github.com/ksharma6/Inbox0/pull/53))
 - GitHub and CI maintenance ([#52](https://github.com/ksharma6/Inbox0/pull/52))
 - Updated pre-commit configuration and CI workflow to target Python 3.11 ([#40](https://github.com/ksharma6/Inbox0/pull/40))
-- Removed stale `inbox_zero` dependency from `requirements.txt` ([#39](https://github.com/ksharma6/Inbox0/pull/39))
+- Removed stale `Inbox0` dependency from `requirements.txt` ([#39](https://github.com/ksharma6/Inbox0/pull/39))
 
 ### Dependencies
 - Bumped `openai` 2.17.0 → 2.30.0 ([#46](https://github.com/ksharma6/Inbox0/pull/46))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to Inbox0 are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+---
+
+## [0.1.0] — 2026-04-10
+
+### Added
+- LangSmith tracing support and `load_env` required variable validation ([#57](https://github.com/ksharma6/Inbox0/pull/57))
+- Fixture and email dataset generation for testing ([#49](https://github.com/ksharma6/Inbox0/pull/49))
+- GitHub CI pipeline ([#38](https://github.com/ksharma6/Inbox0/pull/38))
+- Timing and token counting logger ([#37](https://github.com/ksharma6/Inbox0/pull/37))
+- OpenRouter implementation and refactor — any OpenAI SDK-compatible provider supported ([#16](https://github.com/ksharma6/Inbox0/pull/16))
+- Logging module ([#14](https://github.com/ksharma6/Inbox0/pull/14))
+- End-to-end email triage and drafting workflow ([#6](https://github.com/ksharma6/Inbox0/pull/6))
+- Gmail Reader refactor ([#5](https://github.com/ksharma6/Inbox0/pull/5))
+- Gmail Reader functionality integrated into agent ([#4](https://github.com/ksharma6/Inbox0/pull/4))
+- OpenAI agent base class for reading and writing Gmail ([#3](https://github.com/ksharma6/Inbox0/pull/3))
+- Agent can send emails ([#2](https://github.com/ksharma6/Inbox0/pull/2))
+- GmailWriter class ([#1](https://github.com/ksharma6/Inbox0/pull/1))
+
+### Documentation
+- Updated README badges and links for Inbox0 rename ([#55](https://github.com/ksharma6/Inbox0/pull/55))
+- Architecture Decision Record: classification dataset ([#48](https://github.com/ksharma6/Inbox0/pull/48))
+- Architecture Decision Record: email cache and parallelization strategy ([#35](https://github.com/ksharma6/Inbox0/pull/35))
+- Updated README banner ([#32](https://github.com/ksharma6/Inbox0/pull/32))
+- Added Contributor Covenant Code of Conduct ([#22](https://github.com/ksharma6/Inbox0/pull/22))
+- Open-source hygiene: issue templates, contributing guide, and repo metadata ([#23](https://github.com/ksharma6/Inbox0/pull/23))
+
+### Maintenance
+- Added Codecov test results upload and ignored generated report files ([#54](https://github.com/ksharma6/Inbox0/pull/54))
+- Fixed Codecov unknown status — upgraded action to v5 and added `codecov.yml` ([#53](https://github.com/ksharma6/Inbox0/pull/53))
+- GitHub and CI maintenance ([#52](https://github.com/ksharma6/Inbox0/pull/52))
+- Updated pre-commit configuration and CI workflow to target Python 3.11 ([#40](https://github.com/ksharma6/Inbox0/pull/40))
+- Removed stale `inbox_zero` dependency from `requirements.txt` ([#39](https://github.com/ksharma6/Inbox0/pull/39))
+
+### Dependencies
+- Bumped `openai` 2.17.0 → 2.30.0 ([#46](https://github.com/ksharma6/Inbox0/pull/46))
+- Bumped `pydantic-core` 2.41.5 → 2.45.0 ([#45](https://github.com/ksharma6/Inbox0/pull/45))
+- Bumped `slack-bolt` 1.27.0 → 1.28.0 ([#44](https://github.com/ksharma6/Inbox0/pull/44))
+- Bumped `langchain` 1.2.9 → 1.2.15 ([#43](https://github.com/ksharma6/Inbox0/pull/43))
+- Bumped `tiktoken` 0.9.0 → 0.12.0 ([#42](https://github.com/ksharma6/Inbox0/pull/42))
+- Bumped `google-api-python-client` 2.189.0 → 2.193.0 ([#28](https://github.com/ksharma6/Inbox0/pull/28))
+- Bumped `google-auth-oauthlib` 1.2.4 → 1.3.1 ([#27](https://github.com/ksharma6/Inbox0/pull/27))
+- Bumped `openrouter` 0.6.0 → 0.8.1 ([#26](https://github.com/ksharma6/Inbox0/pull/26))
+- Bumped `werkzeug` 3.1.5 → 3.1.8 ([#25](https://github.com/ksharma6/Inbox0/pull/25))
+- Bumped `uuid-utils` 0.14.0 → 0.14.1 ([#24](https://github.com/ksharma6/Inbox0/pull/24))
+- Bumped `flask` 3.1.2 → 3.1.3 ([#21](https://github.com/ksharma6/Inbox0/pull/21))
+- Bumped `pygments` 2.19.2 → 2.20.0 ([#20](https://github.com/ksharma6/Inbox0/pull/20))
+
+---
+
+[Unreleased]: https://github.com/ksharma6/Inbox0/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/ksharma6/Inbox0/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Thank you for your interest in contributing! This document covers how to get set
 
 ## Reporting bugs or requesting features
 
-Open an issue at [github.com/ksharma6/inbox_zero/issues](https://github.com/ksharma6/inbox_zero/issues) and provide as much context as possible.
+Open an issue at [github.com/ksharma6/Inbox0/issues](https://github.com/ksharma6/Inbox0/issues) and provide as much context as possible.
 
 ## Code of Conduct
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "inbox_zero"
+name = "Inbox0"
 version = "0.1.0"
 description = "Inbox Zero"
 authors = [{ name = "Kishen Sharma", email = "ksharma06@pm.me" }]


### PR DESCRIPTION
#### Reference Issues/PRs
No issue — new file addition.


#### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation only

#### What does this implement/fix? Explain your changes.
Adds a `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format and Semantic Versioning. Captures all 39 merged PRs under a `v0.1.0` release, organized into Added, Documentation, Maintenance, and Dependencies sections. Includes comparison links for `[Unreleased]` and `[0.1.0]` to support future release diffs on GitHub.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Accuracy of PR categorization (Added vs Maintenance vs Docs)
- Whether any PRs were miscategorized or should be excluded
- The `v0.1.0` release date (set to 2026-04-10, the most recent merge)

#### Did you add any tests for the change?
No — documentation only.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [SEC], or [BREAKING]
- [ ] Tests added or updated for any changed behaviour
- [x] No secrets, credentials, or `.env` values committed
- [x] `pyproject.toml` updated if new dependencies were added and `uv.lock` regenerated via `uv sync`