### PR TITLE
[ENH] Add retry logic for transient LLM and Gmail read failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased]
+## [0.1.1] — 2026-04-25
+
+### Added
+- Fail-fast Pydantic validation at external boundaries: Flask workflow requests, Slack action payloads, Gmail message parsing, and `AgentSchema` API-key configuration ([#71](https://github.com/ksharma6/Inbox0/pull/71))
+- Retry logic for transient OpenAI/OpenRouter-compatible LLM failures and Gmail read API failures using exponential backoff.
+- Focused tests for schema validation, environment-variable fallback behavior, Gmail malformed-response handling, and retry behavior.
+
+### Changed
+- Aligned environment loading and workflow construction with `AgentSchema`, including support for either `OPENROUTER_API_KEY` or `OPENAI_API_KEY` ([#71](https://github.com/ksharma6/Inbox0/pull/71))
+- Updated `src/workflows/factory.py` to construct the workflow through `Agent`/`AgentSchema` instead of a raw `OpenRouter` client ([#71](https://github.com/ksharma6/Inbox0/pull/71))
+
+### Maintenance
+- Updated CI to use `actions/checkout@v5` and `codecov/codecov-action@v5` for both coverage and test-result uploads ([#71](https://github.com/ksharma6/Inbox0/pull/71))
+- Updated `pip-audit` CI behavior to ignore the currently unactionable `pip` CVE while preserving audit enforcement for other vulnerabilities ([#71](https://github.com/ksharma6/Inbox0/pull/71))
+
+### Dependencies
+- Bumped `langsmith` 0.7.30 → 0.7.36 ([#71](https://github.com/ksharma6/Inbox0/pull/71))
+- Added `tenacity` as a direct dependency for retry handling.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "google-auth-oauthlib>=1.3",
     "redis>=7.0",
     "slack_bolt>=1.28",
+    "tenacity>=9.1",
     "tiktoken>=0.12",
     "python-dotenv",
     "PyYAML>=6.0",

--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -4,13 +4,14 @@ import time
 from typing import Callable, Dict
 
 import tiktoken
-from openai import OpenAI
+from openai import APIConnectionError, APITimeoutError, InternalServerError, OpenAI, RateLimitError
 from openai.types.chat import ChatCompletion
 from src.gmail.gmail_reader import GmailReader
 from src.gmail.gmail_writer import GmailWriter
 from src.models.agent_schemas import AgentSchema, ProcessRequestSchema
 from src.slack_handlers.draft_approval_handler import DraftApprovalHandler
 from src.utils.usage_tracker import UsageTracker
+from tenacity import before_sleep_log, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,6 @@ class Agent:
                 "X-Title": schema.app_name,
             },
         )
-        # Map available tools to their methods
         self._setup_function_map()
 
     def _setup_function_map(self):
@@ -46,16 +46,13 @@ class Agent:
             return
         for tool_name, instance in self.available_tools.items():
             if isinstance(instance, GmailWriter):
-                # Map GmailWriter methods to function names
                 self.function_map["create_draft"] = instance.create_draft
                 self.function_map["send_draft"] = instance.send_draft
                 self.function_map["save_draft"] = instance.save_draft
                 self.function_map["send_reply"] = instance.send_reply
             elif isinstance(instance, GmailReader):
-                # Map GmailReader methods to function names
                 self.function_map["read_emails"] = instance.read_emails
             elif isinstance(instance, DraftApprovalHandler):
-                # Map DraftApprovalHandler methods to function names
                 self.function_map["send_draft_for_approval"] = instance.send_draft_for_approval
             else:
                 logger.error(f"Unknown tool type: {type(instance)} for tool: {tool_name}")
@@ -78,6 +75,17 @@ class Agent:
                 total += len(encoding.encode(content))
         return total
 
+    @retry(
+        retry=retry_if_exception_type((APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)),
+        wait=wait_exponential(multiplier=1, min=1, max=8),
+        stop=stop_after_attempt(3),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
+    def _create_chat_completion(self, **kwargs) -> ChatCompletion:
+        """Retry transient OpenAI/OpenRouter-compatible completion failures."""
+        return self.client.chat.completions.create(**kwargs)
+
     def _timed_completion(self, label: str, **kwargs) -> ChatCompletion:
         """Wraps chat.completions.create with pre-flight token estimation and duration logging"""
         est_tokens = self._estimate_prompt_tokens(kwargs.get("messages", []))
@@ -91,7 +99,7 @@ class Agent:
             },
         )
         t0 = time.perf_counter()
-        response = self.client.chat.completions.create(**kwargs)
+        response = self._create_chat_completion(**kwargs)
         elapsed_ms = (time.perf_counter() - t0) * 1000
         usage = response.usage
         tps = (usage.completion_tokens / (elapsed_ms / 1000)) if elapsed_ms > 0 else 0
@@ -117,7 +125,7 @@ class Agent:
         return response
 
     def process_request(self, schema: ProcessRequestSchema, max_iterations: int = 5):
-        """Processes user's request by interacting with OpenAI model.
+        """Processes user's request by interacting with OpenRouter model.
 
         Args:
             schema (ProcessRequestSchema): Request schema containing user prompt, tool schema, and system message
@@ -139,7 +147,7 @@ class Agent:
 
         logger.info("Messages: %s", messages)
 
-        # Convert tool schema(s) to proper OpenAI format
+        # Convert tool schema(s) to proper OpenRouter format
         # Handle both single ToolFunction and list of ToolFunctions
         tools_payload = None  # Default to None
         if schema.llm_tool_schema:  # Only process if not None
@@ -190,11 +198,9 @@ class Agent:
                     function_to_call = self.function_map.get(function_name)
 
                     if function_to_call:
-                        # Handle missing keys in function_args if they are optional
                         try:
                             function_args = json.loads(function_args_str)
 
-                            # Special handling for Slack functions that need draft
                             if function_name in ["send_draft_for_approval"]:
                                 if "draft" not in function_args or not function_args["draft"]:
                                     result = (
@@ -215,8 +221,7 @@ class Agent:
                                 f"Error decoding arguments for {function_name}. "
                                 "Trying to call without arguments or with defaults."
                             )
-                            # Attempt to call with no args if appropriate, or handle default
-                            if function_name == "read_emails":  # Example: read_emails might default
+                            if function_name == "read_emails":
                                 result = function_to_call()
                             else:
                                 result = f"Error: Invalid arguments for {function_name}."
@@ -227,7 +232,7 @@ class Agent:
                                 "tool_call_id": tool_call.id,
                                 "role": "tool",
                                 "name": function_name,
-                                "content": str(result),  # Ensure content is a string
+                                "content": str(result),
                             }
                         )
                     else:
@@ -242,17 +247,13 @@ class Agent:
                                      {list(self.function_map.keys())}",
                             }
                         )
-
-                # Continue to next iteration for more tool calls
                 iteration += 1
 
             else:
-                # No more tool calls, get final response
                 final_response = response_message.content
                 logger.info("Agent final response (no more tools needed):\n%s", final_response)
                 return final_response
 
-        # If we reach max iterations, get a final response
         logger.info("Reached maximum iterations (%s). Getting final response...", max_iterations)
         final_response_obj = self._timed_completion("final_max_iterations", model=self.schema.model, messages=messages)
         final_response = final_response_obj.choices[0].message.content

--- a/src/gmail/gmail_reader.py
+++ b/src/gmail/gmail_reader.py
@@ -4,9 +4,21 @@ from typing import Dict, List, Optional
 
 from bs4 import BeautifulSoup
 from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 from src.models.gmail import EmailMessage
+from tenacity import before_sleep_log, retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from .gmail_authenticator import auth_user
+
+logger = logging.getLogger(__name__)
+
+
+def _is_transient_gmail_error(exc: BaseException) -> bool:
+    """Return True for Gmail API errors that are safe to retry for read calls."""
+    if isinstance(exc, HttpError):
+        status = getattr(exc.resp, "status", None)
+        return status == 429 or (status is not None and 500 <= status < 600)
+    return isinstance(exc, (ConnectionError, TimeoutError))
 
 
 class GmailReader:
@@ -34,6 +46,17 @@ class GmailReader:
         self.path = path
         self.creds = auth_user(self.path)
         self.service = build("gmail", "v1", credentials=self.creds)
+
+    @retry(
+        retry=retry_if_exception(_is_transient_gmail_error),
+        wait=wait_exponential(multiplier=1, min=1, max=8),
+        stop=stop_after_attempt(3),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
+    def _execute_read_request(self, request):
+        """Execute a Gmail read request with retry for transient API failures."""
+        return request.execute()
 
     def read_emails(
         self,
@@ -73,7 +96,7 @@ class GmailReader:
         # list of user's messages - capped at 25 messages
         list_params = {"userId": "me", "maxResults": min(count, 25), "q": query}
 
-        results = self.service.users().messages().list(**list_params).execute()
+        results = self._execute_read_request(self.service.users().messages().list(**list_params))
         messages = results.get("messages", [])
 
         if not messages:
@@ -120,8 +143,8 @@ class GmailReader:
         """
         try:
             if not message_detail:
-                message_detail = (
-                    self.service.users().messages().get(userId="me", id=message_id, format="full").execute()
+                message_detail = self._execute_read_request(
+                    self.service.users().messages().get(userId="me", id=message_id, format="full")
                 )
 
             if not message_detail:

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -1,11 +1,14 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+import httpx
+from openai import APIConnectionError
 from src.agent.agent import Agent
 from src.gmail.gmail_reader import GmailReader
 from src.gmail.gmail_writer import GmailWriter
 from src.models.agent_schemas import AgentSchema
 from src.slack_handlers.draft_approval_handler import DraftApprovalHandler
+from tenacity import wait_none
 
 
 class TestAgent(unittest.TestCase):
@@ -51,3 +54,23 @@ class TestAgent(unittest.TestCase):
             self.agent.function_map["send_draft_for_approval"],
             self.mock_draft_approval_handler.send_draft_for_approval,
         )
+
+    def test_create_chat_completion_retries_transient_failure(self):
+        """Transient OpenAI/OpenRouter-compatible errors are retried."""
+        expected_response = MagicMock()
+        transient_error = APIConnectionError(
+            message="temporary connection failure",
+            request=httpx.Request("POST", "https://example.test/v1/chat/completions"),
+        )
+        self.agent.client = MagicMock()
+        create = self.agent.client.chat.completions.create
+        create.side_effect = [transient_error, expected_response]
+
+        result = self.agent._create_chat_completion.retry_with(wait=wait_none())(
+            self.agent,
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+        self.assertEqual(result, expected_response)
+        self.assertEqual(create.call_count, 2)

--- a/tests/gmail/test_gmail_reader.py
+++ b/tests/gmail/test_gmail_reader.py
@@ -14,11 +14,14 @@ Covers the defensive changes in ``src/gmail/gmail_reader.py`` and
 
 import base64
 import logging
+from unittest.mock import Mock
 
 import pytest
+from googleapiclient.errors import HttpError
 from pydantic import ValidationError
 from src.gmail.gmail_reader import GmailReader
 from src.models.gmail import EmailMessage
+from tenacity import wait_none
 
 VALID_THREAD_ID = "thread_abc123"
 
@@ -101,6 +104,20 @@ class TestGetEmailMessagePayloadGuard:
 
         assert result is None
         assert any("[GMAIL_PAYLOAD_MISSING]" in r.getMessage() for r in caplog.records)
+
+
+class TestGmailReaderRetry:
+    """Gmail read requests retry transient API failures."""
+
+    def test_execute_read_request_retries_transient_http_error(self, reader):
+        transient_error = HttpError(resp=Mock(status=500, reason="server error"), content=b"temporary failure")
+        request = Mock()
+        request.execute.side_effect = [transient_error, {"messages": []}]
+
+        result = reader._execute_read_request.retry_with(wait=wait_none())(reader, request)
+
+        assert result == {"messages": []}
+        assert request.execute.call_count == 2
 
 
 class TestGetEmailMessageExceptionLogging:

--- a/uv.lock
+++ b/uv.lock
@@ -739,6 +739,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "redis" },
     { name = "slack-bolt" },
+    { name = "tenacity" },
     { name = "tiktoken" },
     { name = "uuid-utils" },
 ]
@@ -766,6 +767,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "redis", specifier = ">=7.0" },
     { name = "slack-bolt", specifier = ">=1.28" },
+    { name = "tenacity", specifier = ">=9.1" },
     { name = "tiktoken", specifier = ">=0.12" },
     { name = "uuid-utils" },
 ]


### PR DESCRIPTION
#### Title
[ENH] Add retry logic for transient LLM and Gmail read failures

#### Reference Issues/PRs
Fixes https://github.com/ksharma6/Inbox0/issues/72
Follow-up issue planned for idempotent GmailWriter and Slack write/action retry strategy.


#### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Breaking change

#### What does this implement/fix? Explain your changes.
This PR adds retry protection for the low-risk external calls identified in #72: OpenRouter/OpenAI-compatible LLM calls and Gmail read requests.

Implemented changes:
- Adds tenacity retry handling around LLM chat completion calls in Agent, retrying transient provider/network failures such as connection errors, timeouts, rate limits, and internal server errors.
- Adds retry handling around Gmail `read execute()` calls in GmailReader, limited to transient read failures such as 429, 5xx, connection errors, and timeouts.
- Keeps retries intentionally scoped away from side-effectful operations like Slack sends, Gmail draft creation, Gmail sends/replies, and approval/save/reject action handling.
-Adds tenacity as a direct dependency in pyproject.toml and refreshes uv.lock.
- Updates the changelog for the 0.1.1 reliability and maintenance release.
- This directly addresses the first-pass retry scope in #72 while preserving the safer follow-up design for write-side idempotency.

#### Does your contribution introduce a new dependency? If yes, which one?
`tenacity>=9.1`
It is used for bounded retries with exponential backoff around transient LLM and Gmail read failures.

#### What should a reviewer concentrate their feedback on?
- Whether the retry exception lists are scoped correctly for OpenAI/OpenRouter-compatible LLM calls.
- Whether Gmail retry behavior is limited to safe read operations and transient failures.
- Whether the backoff policy is reasonable for user-facing latency.
- Whether the PR correctly avoids retries for GmailWriter and Slack write/action paths until idempotency protections are designed.

#### Did you add any tests for the change?
Added focused retry tests for:
- LLM completion retry after a transient APIConnectionError.
- Gmail read retry after a transient Gmail 500 HttpError.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [SEC], or [BREAKING]
    - [BUG] - bugfix
    - [MNT] - CI, test framework, dependency updates
    - [ENH] - adding or improving code
    - [DOC] - writing or improving documentation or docstrings
    - [SEC] - security fixes or vulnerability patches
    - [BREAKING] - any change that requires user to update their setup or code 
- [x] Tests added or updated for any changed behaviour
- [x] No secrets, credentials, or `.env` values committed
- [x] `pyproject.toml` updated if new dependencies were added and `uv.lock` regenerated via `uv sync`