### PR TITLE
[ENH] Include Gmail thread ID in thread context queries

### DIFF
--- a/src/gmail/gmail_reader.py
+++ b/src/gmail/gmail_reader.py
@@ -64,25 +64,28 @@ class GmailReader:
         unread_only: bool = False,
         include_body: bool = True,
         primary_only: bool = True,
-        thread_id: Optional[List[str]] = None,
+        thread_id: Optional[str] = None,
     ) -> List[EmailMessage]:
         """
         Read emails from the user's inbox.
 
         Builds a Gmail query targeting the Inbox (and Primary by default), then fetches
-        up to `count` messages and returns them as `EmailMessage` models.
+        up to `count` messages and returns them as `EmailMessage` models. If `thread_id`
+        is provided, restricts to the given thread. If `thread_id` is not provided,
+        returns up to `count` messages from the inbox.
 
         Args:
             count (int): Minimum number of messages to fetch (capped at 25).
             unread_only (bool): If True, restricts to unread messages.
             include_body (bool): If True, includes the parsed body text.
             primary_only (bool): If True, restricts to the Primary category.
+            thread_id (Optional[str]): If provided, restricts the query to the given thread.
 
         Returns:
             List[EmailMessage]: Messages in reverse-chronological order from the inbox.
         """
 
-        # target inbox emails only
+        # target primary category in gmail inbox
         query_parts = ["in:inbox"]
 
         if primary_only:
@@ -90,6 +93,9 @@ class GmailReader:
 
         if unread_only:
             query_parts.append("is:unread")
+
+        if thread_id:
+            query_parts.append(f"threadId:{thread_id}")
 
         query = " ".join(query_parts)
 

--- a/tests/gmail/test_gmail_reader.py
+++ b/tests/gmail/test_gmail_reader.py
@@ -120,6 +120,19 @@ class TestGmailReaderRetry:
         assert request.execute.call_count == 2
 
 
+class TestGetRecentEmailsInThread:
+    """Thread lookups must include the requested Gmail thread id in the API query."""
+
+    def test_adds_thread_id_to_gmail_query(self, reader):
+        reader._execute_read_request = Mock(return_value={"messages": []})
+
+        reader.get_recent_emails_in_thread(VALID_THREAD_ID, count=2)
+
+        list_kwargs = reader.service.users.return_value.messages.return_value.list.call_args.kwargs
+        assert list_kwargs["maxResults"] == 2
+        assert f"threadId:{VALID_THREAD_ID}" in list_kwargs["q"]
+
+
 class TestGetEmailMessageExceptionLogging:
     """Exceptions during processing emit ``[GMAIL_FETCH_ERROR]`` logs."""
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #60 

#### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only

#### What does this implement/fix? Explain your changes.
This fixes `GmailReader.get_recent_emails_in_thread(...)` so thread context lookups are actually scoped to the requested Gmail thread.

Previously, `get_recent_emails_in_thread(thread_id, count=2)` passed `thread_id` into `read_emails(...)`, but `read_emails(...)` never added that value to the Gmail API query. As a result, thread-context reads silently fell back to a generic inbox query like:

```text
in:inbox category:primary
```
This meant the workflow could pull arbitrary inbox messages instead of the two most recent messages from the target thread.

The fix appends the Gmail thread query term when thread_id is provided:
```
threadId:<thread_id>
```
So thread context reads now query Gmail with a scoped search like:
```
in:inbox category:primary threadId:thread_abc123
```
The existing unread Primary inbox behavior remains unchanged for normal inbox reads.

**Does your contribution introduce a new dependency? If yes, which one?**
No.

**What should a reviewer concentrate their feedback on?**

- Confirm that read_emails(...) preserves the existing unread Primary inbox behavior.
- Confirm that get_recent_emails_in_thread(...) now scopes Gmail API list queries to the provided thread ID.
- Confirm the regression test captures the previous failure mode without requiring real Gmail API calls.

**Did you add any tests for the change?**
Yes. Added a focused regression test for get_recent_emails_in_thread(...) that verifies the Gmail messages().list(...) query includes threadId:<thread_id>.


- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [SEC], or [BREAKING]
[BUG] - bugfix
[MNT] - CI, test framework, dependency updates
[ENH] - adding or improving code
[DOC] - writing or improving documentation or docstrings
[SEC] - security fixes or vulnerability patches
[BREAKING] - any change that requires user to update their setup or code

-  [x] Tests added or updated for any changed behaviour
- [x] No secrets, credentials, or .env values committed
-  [x] pyproject.toml updated if new dependencies were added and uv.lock regenerated via uv sync