### PR TITLE
[MNT] Rename workflow state thread_id to workflow_run 

### DIFF
--- a/src/models/agent_schemas.py
+++ b/src/models/agent_schemas.py
@@ -2,7 +2,7 @@ import datetime
 import os
 from typing import Any, Dict, List, Optional
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, Field, field_validator
 from src.models.gmail import EmailMessage, EmailSummary
 
 
@@ -63,13 +63,10 @@ class ProcessRequestSchema(BaseModel):
 class GmailAgentState(BaseModel):
     """State for Gmail processing workflow"""
 
-    model_config = ConfigDict(populate_by_name=True)
-
     # Input
     user_id: str = Field(..., description="Slack user ID requesting email processing")
     workflow_run_id: str = Field(
         ...,
-        validation_alias=AliasChoices("workflow_run_id", "thread_id"),
         description="Unique ID for this workflow run",
     )
 

--- a/src/models/agent_schemas.py
+++ b/src/models/agent_schemas.py
@@ -2,7 +2,7 @@ import datetime
 import os
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 from src.models.gmail import EmailMessage, EmailSummary
 
 
@@ -63,9 +63,15 @@ class ProcessRequestSchema(BaseModel):
 class GmailAgentState(BaseModel):
     """State for Gmail processing workflow"""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     # Input
     user_id: str = Field(..., description="Slack user ID requesting email processing")
-    thread_id: str = Field(..., description="Unique ID for the email processing thread")
+    workflow_run_id: str = Field(
+        ...,
+        validation_alias=AliasChoices("workflow_run_id", "thread_id"),
+        description="Unique ID for this workflow run",
+    )
 
     # Email data
     unread_emails: List[EmailMessage] = Field(default=[], description="List of unread emails")

--- a/src/routes/web/flask_routes.py
+++ b/src/routes/web/flask_routes.py
@@ -27,8 +27,8 @@ def register_flask_routes(app, workflow):
     def start_workflow():
         req = StartWorkflowRequest.model_validate(request.get_json(silent=True) or {})
 
-        thread_id = str(uuid.uuid4())
-        initial_state = GmailAgentState(user_id=req.user_id, thread_id=thread_id)
+        workflow_run_id = str(uuid.uuid4())
+        initial_state = GmailAgentState(user_id=req.user_id, workflow_run_id=workflow_run_id)
 
         result_gen = workflow.workflow.stream(initial_state)
 

--- a/src/workflows/workflow.py
+++ b/src/workflows/workflow.py
@@ -560,12 +560,12 @@ class EmailProcessingWorkflow:
         Returns:
             GmailAgentState object
         """
-        thread_id = str(uuid.uuid4())
+        workflow_run_id = str(uuid.uuid4())
         self._seen_message_ids = set()
 
         initial_state = GmailAgentState(
             user_id=user_id,
-            thread_id=thread_id,
+            workflow_run_id=workflow_run_id,
         )
 
         # run the workflow

--- a/tests/workflows/test_read_unread_emails.py
+++ b/tests/workflows/test_read_unread_emails.py
@@ -40,7 +40,7 @@ def workflow(mocker):
 
 class TestReadUnreadEmails:
     def _make_state(self):
-        return GmailAgentState(user_id="test_user", thread_id="test_thread")
+        return GmailAgentState(user_id="test_user", workflow_run_id="test_workflow_run")
 
     def _setup_mocks(self, workflow, multi_thread_inbox):
         """


### PR DESCRIPTION
#### Reference Issues/PRs
Na

#### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only

#### What does this implement/fix? Explain your changes.
This renames the workflow run identifier on `GmailAgentState` from `thread_id` to `workflow_run_id`.

Previously, `GmailAgentState.thread_id` represented an app workflow run ID, but the codebase also uses `EmailMessage.thread_id` for actual Gmail conversation threads. Having both meanings use `thread_id` made the state persistence and resume workflow code harder to reason about.

This change makes the distinction explicit:

```text
GmailAgentState.workflow_run_id  # app workflow execution ID
EmailMessage.thread_id           # Gmail conversation thread ID
```
#### Did you add any tests for the change?
Updated existing workflow tests to construct GmailAgentState with workflow_run_id.

#### What should a reviewer concentrate their feedback on?
- Confirm that workflow_run_id is clear and accurately describes the app-generated workflow run identifier.
- Confirm that remaining thread_id usage refers only to Gmail email conversation threads.
- Confirm that this rename does not change runtime behavior beyond the field name cleanup.

Did you add any tests for the change?
Updated existing workflow tests to construct GmailAgentState with workflow_run_id.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [SEC], or [BREAKING]
    - [BUG] - bugfix
    - [MNT] - CI, test framework, dependency updates
    - [ENH] - adding or improving code
    - [DOC] - writing or improving documentation or docstrings
    - [SEC] - security fixes or vulnerability patches
    - [BREAKING] - any change that requires user to update their setup or code 
- [x] Tests added or updated for any changed behaviour
- [x] No secrets, credentials, or `.env` values committed
- [x] `pyproject.toml` updated if new dependencies were added and `uv.lock` regenerated via `uv sync`