### PR TITLE
[BREAKING] Resume workflows by workflow run ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.2.0] — 2026-05-08
+
+### Breaking Changed
+- Workflow state is now persisted and resumed by `workflow_run_id` instead of Slack `user_id`, so `/resume_workflow` callers must provide the `workflow_run_id` returned by `/start_workflow`.
+- Slack draft approval buttons now carry `workflow_run_id` so approval actions resume the specific workflow run they belong to rather than the latest saved run for a user.
+
+### Fixed
+- Prevented concurrent workflow runs for the same Slack user from overwriting each other in persisted state.
+
+### Maintenance
+- Clarified workflow state naming by using `workflow_run_id` for app workflow runs, keeping `thread_id` reserved for Gmail conversation threads.
+- Expanded focused test coverage around workflow state persistence, Slack resume routing, and workflow-run ID validation.
+
+---
+
 ## [0.1.1] — 2026-04-25
 
 ### Added

--- a/src/routes/integrations_slack/slack_routes.py
+++ b/src/routes/integrations_slack/slack_routes.py
@@ -33,6 +33,14 @@ def _parse_slack_action(body, event_name):
         return None
 
 
+def _workflow_run_id_from_action_value(value: str) -> str | None:
+    """Extract workflow_run_id from action values formatted as action:workflow_run_id:draft_id."""
+    parts = value.split(":", 2)
+    if len(parts) == 3:
+        return parts[1]
+    return None
+
+
 def register_slack_routes(app, slack_app: SlackApp, workflow):
     @slack_app.action("approve_draft")
     def approve_draft_action(ack, body, respond):
@@ -45,7 +53,7 @@ def register_slack_routes(app, slack_app: SlackApp, workflow):
             return
 
         workflow.draft_handler.handle_approval_action(ack, body, respond)
-        resume_workflow_after_action(parsed.user.id, respond, workflow)
+        resume_workflow_after_action(_workflow_run_id_from_action_value(parsed.actions[0].value), respond, workflow)
 
     @slack_app.action("reject_draft")
     def reject_draft_action(ack, body, respond):
@@ -58,7 +66,7 @@ def register_slack_routes(app, slack_app: SlackApp, workflow):
             return
 
         workflow.draft_handler.handle_approval_action(ack, body, respond)
-        resume_workflow_after_action(parsed.user.id, respond, workflow)
+        resume_workflow_after_action(_workflow_run_id_from_action_value(parsed.actions[0].value), respond, workflow)
 
     @slack_app.action("save_draft")
     def save_draft_action(ack, body, respond):
@@ -71,7 +79,7 @@ def register_slack_routes(app, slack_app: SlackApp, workflow):
             return
 
         workflow.draft_handler.handle_approval_action(ack, body, respond)
-        resume_workflow_after_action(parsed.user.id, respond, workflow)
+        resume_workflow_after_action(_workflow_run_id_from_action_value(parsed.actions[0].value), respond, workflow)
 
     action_dispatch = {
         "approve_draft": approve_draft_action,

--- a/src/routes/web/flask_routes.py
+++ b/src/routes/web/flask_routes.py
@@ -39,24 +39,36 @@ def register_flask_routes(app, workflow):
 
             if state.awaiting_approval:
                 save_state_to_store(state)
-                return jsonify({"status": "paused", "awaiting_approval": True})
+                return jsonify(
+                    {
+                        "status": "paused",
+                        "awaiting_approval": True,
+                        "workflow_run_id": state.workflow_run_id,
+                    }
+                )
             final_state = state
 
         save_state_to_store(final_state)
-        return jsonify({"status": "completed", "workflow_complete": final_state.workflow_complete})
+        return jsonify(
+            {
+                "status": "completed",
+                "workflow_complete": final_state.workflow_complete,
+                "workflow_run_id": final_state.workflow_run_id,
+            }
+        )
 
     @app.route("/resume_workflow", methods=["POST"])
     def resume_workflow():
         req = ResumeWorkflowRequest.model_validate(request.get_json(silent=True) or {})
 
-        state = load_state_from_store(req.user_id)
+        state = load_state_from_store(req.workflow_run_id)
 
         if state is None:
             return (
                 jsonify(
                     {
                         "error": "no_paused_workflow",
-                        "message": f"No saved workflow state found for user_id={req.user_id}",
+                        "message": f"No saved workflow state found for workflow_run_id={req.workflow_run_id}",
                     }
                 ),
                 404,
@@ -86,4 +98,10 @@ def register_flask_routes(app, workflow):
                 new_state = GmailAgentState(**actual_state)
             final_state = new_state
         save_state_to_store(final_state)
-        return jsonify({"status": "resumed", "workflow_complete": final_state.workflow_complete})
+        return jsonify(
+            {
+                "status": "resumed",
+                "workflow_complete": final_state.workflow_complete,
+                "workflow_run_id": final_state.workflow_run_id,
+            }
+        )

--- a/src/routes/web/schemas.py
+++ b/src/routes/web/schemas.py
@@ -32,4 +32,5 @@ class ResumeWorkflowRequest(BaseModel):
         pattern=SLACK_USER_ID_PATTERN,
         description=SLACK_USER_ID_DESCRIPTION,
     )
+    workflow_run_id: str = Field(..., description="Workflow run ID returned by /start_workflow")
     action: ResumeAction = Field(..., description="Action to take on the current draft")

--- a/src/slack_handlers/draft_approval_handler.py
+++ b/src/slack_handlers/draft_approval_handler.py
@@ -45,13 +45,16 @@ class DraftApprovalHandler:
         self.draft_timeouts = {}
         self.DRAFT_TIMEOUT_HOURS = 24
 
-    def send_draft_for_approval(self, draft: Dict, user_id: str) -> Optional[str]:
+    def send_draft_for_approval(
+        self, draft: Dict, user_id: str, workflow_run_id: Optional[str] = None
+    ) -> Optional[str]:
         """
         Send a draft email for approval with interactive buttons.
 
         parameters:
             draft (Dict): Gmail draft dictionary from create_draft()
             user_id (str): Slack user ID to send approval request to
+            workflow_run_id (Optional[str]): Workflow run ID to resume when the user acts on the draft
 
         Returns:
             str: The draft ID for tracking, or None if failed to send draft for approval
@@ -66,13 +69,14 @@ class DraftApprovalHandler:
                 "draft": draft,
                 "decoded_draft": decoded_draft,
                 "user_id": user_id,
+                "workflow_run_id": workflow_run_id,
                 "created_at": datetime.now(),
                 "status": "pending",
             }
 
             self.draft_timeouts[draft_id] = datetime.now() + timedelta(hours=self.DRAFT_TIMEOUT_HOURS)
 
-            approval_message = self._create_approval_message(decoded_draft, draft_id)
+            approval_message = self._create_approval_message(decoded_draft, draft_id, workflow_run_id)
 
             # Send to Slack
             target = user_id
@@ -94,13 +98,16 @@ class DraftApprovalHandler:
             logging.exception("Unexpected error sending draft for approval")
             raise
 
-    def _create_approval_message(self, decoded_draft: Dict, draft_id: str) -> Dict:
+    def _create_approval_message(
+        self, decoded_draft: Dict, draft_id: str, workflow_run_id: Optional[str] = None
+    ) -> Dict:
         """
         Create the approval message with interactive buttons.
 
         parameters:
             decoded_draft (Dict): Decoded draft data
             draft_id (str): Unique draft identifier
+            workflow_run_id (Optional[str]): Workflow run ID to include in Slack action values
 
         Returns:
             Dict: Message text and blocks for Slack approval message
@@ -117,6 +124,11 @@ class DraftApprovalHandler:
             attachment_list = ", ".join(attachments)
             text += f"*Attachments:* {attachment_list}\n"
 
+        def action_value(action_type: str) -> str:
+            if workflow_run_id:
+                return f"{action_type}:{workflow_run_id}:{draft_id}"
+            return f"{action_type}_{draft_id}"
+
         # define slack blocks for approval message
         blocks = [
             {"type": "section", "text": {"type": "mrkdwn", "text": text}},
@@ -132,7 +144,7 @@ class DraftApprovalHandler:
                             "emoji": True,
                         },
                         "style": "primary",
-                        "value": f"approve_{draft_id}",
+                        "value": action_value("approve"),
                         "action_id": "approve_draft",
                     },
                     {
@@ -143,7 +155,7 @@ class DraftApprovalHandler:
                             "emoji": True,
                         },
                         "style": "danger",
-                        "value": f"reject_{draft_id}",
+                        "value": action_value("reject"),
                         "action_id": "reject_draft",
                     },
                     {
@@ -153,7 +165,7 @@ class DraftApprovalHandler:
                             "text": "💾 Save Draft",
                             "emoji": True,
                         },
-                        "value": f"save_{draft_id}",
+                        "value": action_value("save"),
                         "action_id": "save_draft",
                     },
                 ],
@@ -191,7 +203,10 @@ class DraftApprovalHandler:
             value = action["value"]
             user_id = body["user"]["id"]
 
-            action_type, draft_id = value.split("_", 1)
+            if ":" in value:
+                action_type, _, draft_id = value.split(":", 2)
+            else:
+                action_type, draft_id = value.split("_", 1)
 
             # Check if draft exists and is still pending
             if draft_id not in self.pending_drafts:

--- a/src/slack_handlers/workflow_bridge.py
+++ b/src/slack_handlers/workflow_bridge.py
@@ -7,9 +7,14 @@ from src.workflows.state_manager import (
 from src.workflows.workflow import EmailProcessingWorkflow
 
 
-def resume_workflow_after_action(user_id: str, respond, workflow: EmailProcessingWorkflow):
-    state = load_state_from_store(user_id)
+def resume_workflow_after_action(workflow_run_id: str | None, respond, workflow: EmailProcessingWorkflow):
+    if not workflow_run_id:
+        respond(":warning: Could not resume workflow: missing workflow run ID.")
+        return
+
+    state = load_state_from_store(workflow_run_id)
     if state is None:
+        respond(":warning: Could not resume workflow: saved state was not found.")
         return
     if isinstance(state, dict):
         state = GmailAgentState(**extract_langgraph_state(state))

--- a/src/workflows/state_manager.py
+++ b/src/workflows/state_manager.py
@@ -16,7 +16,7 @@ class StateManager:
     Example:
         state_manager = StateManager(storage_backend="memory")
         state_manager.save_state(state)
-        state_manager.load_state(user_id)
+        state_manager.load_state(workflow_run_id)
     """
 
     def __init__(self, storage_backend: str = "memory"):
@@ -46,16 +46,16 @@ class StateManager:
         serialized_bytes = pickle.dumps(serialized_data)
 
         if self.storage_backend == "memory":
-            self._memory_store[state.user_id] = serialized_bytes
+            self._memory_store[state.workflow_run_id] = serialized_bytes
         elif self.storage_backend == "file":
-            self._save_to_file(state.user_id, serialized_bytes)
+            self._save_to_file(state.workflow_run_id, serialized_bytes)
 
-    def load_state(self, user_id: str) -> Optional[GmailAgentState]:
+    def load_state(self, workflow_run_id: str) -> Optional[GmailAgentState]:
         """
         Load state with proper deserialization
 
         Args:
-            user_id: User ID to load state for
+            workflow_run_id: Workflow run ID to load state for
 
         Returns:
             GmailAgentState object or None if not found
@@ -66,9 +66,9 @@ class StateManager:
         """
         try:
             if self.storage_backend == "memory":
-                serialized_bytes = self._memory_store.get(user_id)
+                serialized_bytes = self._memory_store.get(workflow_run_id)
             elif self.storage_backend == "file":
-                serialized_bytes = self._load_from_file(user_id)
+                serialized_bytes = self._load_from_file(workflow_run_id)
             else:
                 serialized_bytes = None
 
@@ -91,7 +91,7 @@ class StateManager:
             return GmailAgentState(**actual_state)
 
         except Exception as e:
-            print(f"Error loading state for user {user_id}: {e}")
+            print(f"Error loading state for workflow_run_id {workflow_run_id}: {e}")
             return None
 
 
@@ -123,6 +123,6 @@ def save_state_to_store(state: GmailAgentState) -> None:
     state_manager.save_state(state)
 
 
-def load_state_from_store(user_id: str) -> Optional[GmailAgentState]:
+def load_state_from_store(workflow_run_id: str) -> Optional[GmailAgentState]:
     """Load state using the state manager"""
-    return state_manager.load_state(user_id)
+    return state_manager.load_state(workflow_run_id)

--- a/src/workflows/workflow.py
+++ b/src/workflows/workflow.py
@@ -354,6 +354,7 @@ class EmailProcessingWorkflow:
         draft_id = self.draft_handler.send_draft_for_approval(
             draft=draft_info["draft"],
             user_id=state.user_id,
+            workflow_run_id=state.workflow_run_id,
         )
 
         if draft_id:

--- a/tests/agent/test_agent_schemas.py
+++ b/tests/agent/test_agent_schemas.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
-from src.models.agent_schemas import AgentSchema
+from src.models.agent_schemas import AgentSchema, GmailAgentState
 
 
 def test_agent_schema_uses_openrouter_api_key():
@@ -35,3 +35,17 @@ def test_agent_schema_defaults_app_name_to_inbox0():
         schema = AgentSchema()
 
     assert schema.app_name == "Inbox0"
+
+
+def test_gmail_agent_state_uses_workflow_run_id_not_thread_id():
+    state = GmailAgentState(user_id="U090QS5DDEE", workflow_run_id="workflow-run-123")
+
+    assert state.workflow_run_id == "workflow-run-123"
+    assert not hasattr(state, "thread_id")
+
+
+def test_gmail_agent_state_rejects_legacy_thread_id_without_workflow_run_id():
+    with pytest.raises(ValidationError) as exc_info:
+        GmailAgentState(user_id="U090QS5DDEE", thread_id="legacy-thread-id")
+
+    assert any(err["loc"] == ("workflow_run_id",) for err in exc_info.value.errors())

--- a/tests/logging/test_draft_approval_handler_logging.py
+++ b/tests/logging/test_draft_approval_handler_logging.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timedelta
 
 from src.slack_handlers.draft_approval_handler import DraftApprovalHandler
 
@@ -28,3 +29,23 @@ def test_draft_approval_handler_logging(caplog, mocker):
     assert "Draft approved - draft_id=test_draft_id user_id=test_user_id" in caplog.text
     assert "Draft rejected - draft_id=test_draft_id user_id=test_user_id" in caplog.text
     assert "Draft saved - draft_id=test_draft_id user_id=test_user_id" in caplog.text
+
+
+def test_approval_message_button_values_include_workflow_run_id(mocker):
+    slack_app = mocker.Mock()
+    gmail_writer = mocker.Mock()
+    draft_handler = DraftApprovalHandler(gmail_writer=gmail_writer, slack_app=slack_app)
+    draft_handler.draft_timeouts["draft-abc-123"] = datetime.now() + timedelta(hours=1)
+
+    message = draft_handler._create_approval_message(
+        decoded_draft={},
+        draft_id="draft-abc-123",
+        workflow_run_id="workflow-run-123",
+    )
+
+    buttons = message["blocks"][1]["elements"]
+    assert [button["value"] for button in buttons] == [
+        "approve:workflow-run-123:draft-abc-123",
+        "reject:workflow-run-123:draft-abc-123",
+        "save:workflow-run-123:draft-abc-123",
+    ]

--- a/tests/routes/test_flask_routes.py
+++ b/tests/routes/test_flask_routes.py
@@ -21,6 +21,7 @@ from src.routes.web.schemas import (
 )
 
 VALID_SLACK_USER_ID = "U090QS5DDEE"
+VALID_WORKFLOW_RUN_ID = "workflow-run-123"
 
 
 def _make_client(mocker):
@@ -59,8 +60,13 @@ class TestStartWorkflowRequestSchema:
 
 class TestResumeWorkflowRequestSchema:
     def test_accepts_valid_payload(self):
-        req = ResumeWorkflowRequest(user_id=VALID_SLACK_USER_ID, action="approve_draft")
+        req = ResumeWorkflowRequest(
+            user_id=VALID_SLACK_USER_ID,
+            workflow_run_id=VALID_WORKFLOW_RUN_ID,
+            action="approve_draft",
+        )
         assert req.user_id == VALID_SLACK_USER_ID
+        assert req.workflow_run_id == VALID_WORKFLOW_RUN_ID
         assert req.action is ResumeAction.APPROVE_DRAFT
 
     @pytest.mark.parametrize(
@@ -72,16 +78,28 @@ class TestResumeWorkflowRequestSchema:
         ],
     )
     def test_accepts_each_resume_action(self, action_value, expected):
-        req = ResumeWorkflowRequest(user_id=VALID_SLACK_USER_ID, action=action_value)
+        req = ResumeWorkflowRequest(
+            user_id=VALID_SLACK_USER_ID,
+            workflow_run_id=VALID_WORKFLOW_RUN_ID,
+            action=action_value,
+        )
         assert req.action is expected
 
     def test_rejects_unknown_action(self):
         with pytest.raises(ValidationError):
-            ResumeWorkflowRequest(user_id=VALID_SLACK_USER_ID, action="delete_everything")
+            ResumeWorkflowRequest(
+                user_id=VALID_SLACK_USER_ID,
+                workflow_run_id=VALID_WORKFLOW_RUN_ID,
+                action="delete_everything",
+            )
 
     def test_rejects_invalid_user_id(self):
         with pytest.raises(ValidationError):
-            ResumeWorkflowRequest(user_id="test-user-123", action="approve_draft")
+            ResumeWorkflowRequest(
+                user_id="test-user-123",
+                workflow_run_id=VALID_WORKFLOW_RUN_ID,
+                action="approve_draft",
+            )
 
 
 class TestStartWorkflowRoute:
@@ -105,6 +123,45 @@ class TestStartWorkflowRoute:
         assert response.get_json()["error"] == "invalid_request"
         workflow.workflow.stream.assert_not_called()
 
+    def test_completed_response_includes_workflow_run_id(self, mocker):
+        client, workflow = _make_client(mocker)
+        mocker.patch("src.routes.web.flask_routes.uuid.uuid4", return_value=VALID_WORKFLOW_RUN_ID)
+        save_state = mocker.patch("src.routes.web.flask_routes.save_state_to_store")
+        workflow.workflow.stream.return_value = [
+            {"done": {"user_id": VALID_SLACK_USER_ID, "workflow_run_id": VALID_WORKFLOW_RUN_ID}},
+        ]
+
+        response = client.post("/start_workflow", json={"user_id": VALID_SLACK_USER_ID})
+
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["status"] == "completed"
+        assert body["workflow_run_id"] == VALID_WORKFLOW_RUN_ID
+        save_state.assert_called_once()
+
+    def test_paused_response_includes_workflow_run_id(self, mocker):
+        client, workflow = _make_client(mocker)
+        mocker.patch("src.routes.web.flask_routes.uuid.uuid4", return_value=VALID_WORKFLOW_RUN_ID)
+        save_state = mocker.patch("src.routes.web.flask_routes.save_state_to_store")
+        workflow.workflow.stream.return_value = [
+            {
+                "paused": {
+                    "user_id": VALID_SLACK_USER_ID,
+                    "workflow_run_id": VALID_WORKFLOW_RUN_ID,
+                    "awaiting_approval": True,
+                }
+            },
+        ]
+
+        response = client.post("/start_workflow", json={"user_id": VALID_SLACK_USER_ID})
+
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["status"] == "paused"
+        assert body["awaiting_approval"] is True
+        assert body["workflow_run_id"] == VALID_WORKFLOW_RUN_ID
+        save_state.assert_called_once()
+
 
 class TestResumeWorkflowRoute:
     def test_invalid_action_returns_400(self, mocker):
@@ -112,7 +169,11 @@ class TestResumeWorkflowRoute:
 
         response = client.post(
             "/resume_workflow",
-            json={"user_id": VALID_SLACK_USER_ID, "action": "delete_everything"},
+            json={
+                "user_id": VALID_SLACK_USER_ID,
+                "workflow_run_id": VALID_WORKFLOW_RUN_ID,
+                "action": "delete_everything",
+            },
         )
 
         assert response.status_code == 400
@@ -123,18 +184,23 @@ class TestResumeWorkflowRoute:
 
     def test_returns_404_when_no_paused_workflow(self, mocker):
         client, workflow = _make_client(mocker)
-        mocker.patch(
+        load_state = mocker.patch(
             "src.routes.web.flask_routes.load_state_from_store",
             return_value=None,
         )
 
         response = client.post(
             "/resume_workflow",
-            json={"user_id": VALID_SLACK_USER_ID, "action": "approve_draft"},
+            json={
+                "user_id": VALID_SLACK_USER_ID,
+                "workflow_run_id": VALID_WORKFLOW_RUN_ID,
+                "action": "approve_draft",
+            },
         )
 
         assert response.status_code == 404
         body = response.get_json()
         assert body["error"] == "no_paused_workflow"
-        assert VALID_SLACK_USER_ID in body["message"]
+        assert VALID_WORKFLOW_RUN_ID in body["message"]
+        load_state.assert_called_once_with(VALID_WORKFLOW_RUN_ID)
         workflow.workflow.stream.assert_not_called()

--- a/tests/routes/test_slack_routes_validation.py
+++ b/tests/routes/test_slack_routes_validation.py
@@ -21,21 +21,24 @@ from flask import Flask
 from src.routes.integrations_slack import slack_routes as slack_routes_module
 from src.routes.integrations_slack.slack_routes import (
     _parse_slack_action,
+    _workflow_run_id_from_action_value,
     register_slack_routes,
 )
 
 VALID_SLACK_USER_ID = "U090QS5DDEE"
+VALID_WORKFLOW_RUN_ID = "workflow-run-123"
 
 
 def _valid_action_body(action_id="approve_draft", value=None):
     """Minimal Slack action body that passes ``SlackActionBody`` validation."""
+    action_type = action_id.split("_")[0]
     return {
         "user": {"id": VALID_SLACK_USER_ID, "name": "kishen"},
         "team": {"id": "T123", "domain": "example"},
         "actions": [
             {
                 "action_id": action_id,
-                "value": value or f"{action_id.split('_')[0]}_draft-abc-123",
+                "value": value or f"{action_type}:{VALID_WORKFLOW_RUN_ID}:draft-abc-123",
                 "type": "button",
             }
         ],
@@ -111,6 +114,25 @@ class TestParseSlackAction:
         assert "[SLACK_PAYLOAD_INVALID]" in caplog.text
 
 
+class TestWorkflowRunIdFromActionValue:
+    def test_extracts_workflow_run_id_from_new_action_value_format(self):
+        value = f"approve:{VALID_WORKFLOW_RUN_ID}:draft-abc-123"
+
+        assert _workflow_run_id_from_action_value(value) == VALID_WORKFLOW_RUN_ID
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "approve_draft-abc-123",
+            "approve:only-two-parts",
+            "approve",
+            "",
+        ],
+    )
+    def test_returns_none_for_values_without_workflow_run_id(self, value):
+        assert _workflow_run_id_from_action_value(value) is None
+
+
 class TestSlackEventsFormPath:
     def _post_form_payload(self, client, payload_obj):
         """POST a form-encoded Slack interactive payload to /slack/events."""
@@ -161,9 +183,24 @@ class TestSlackEventsFormPath:
         assert response.get_json() == {"response_action": "ack"}
         workflow.draft_handler.handle_approval_action.assert_called_once()
         resume_mock.assert_called_once()
-        # The user_id passed to resume must come from the parsed model, not raw indexing.
-        called_user_id = resume_mock.call_args.args[0]
-        assert called_user_id == VALID_SLACK_USER_ID
+        called_workflow_run_id = resume_mock.call_args.args[0]
+        assert called_workflow_run_id == VALID_WORKFLOW_RUN_ID
+
+    def test_old_style_action_value_does_not_fall_back_to_user_id(self, mocker):
+        resume_mock = mocker.patch.object(slack_routes_module, "resume_workflow_after_action")
+        client, _, workflow = _make_client(mocker)
+
+        response = self._post_form_payload(
+            client,
+            _valid_action_body(action_id="approve_draft", value="approve_draft-abc-123"),
+        )
+
+        assert response.status_code == 200
+        workflow.draft_handler.handle_approval_action.assert_called_once()
+        resume_mock.assert_called_once()
+        called_workflow_run_id = resume_mock.call_args.args[0]
+        assert called_workflow_run_id is None
+        assert called_workflow_run_id != VALID_SLACK_USER_ID
 
     def test_unknown_action_id_falls_through_to_handler(self, mocker):
         # A valid-shaped body with an unknown action_id should NOT dispatch to

--- a/tests/slack_handlers/test_workflow_bridge.py
+++ b/tests/slack_handlers/test_workflow_bridge.py
@@ -1,0 +1,50 @@
+from src.models.agent_schemas import GmailAgentState
+from src.slack_handlers import workflow_bridge
+
+
+def test_resume_workflow_after_action_warns_when_workflow_run_id_missing(mocker):
+    respond = mocker.Mock()
+    workflow = mocker.Mock()
+    load_state = mocker.patch.object(workflow_bridge, "load_state_from_store")
+
+    workflow_bridge.resume_workflow_after_action(None, respond, workflow)
+
+    load_state.assert_not_called()
+    workflow.workflow.stream.assert_not_called()
+    respond.assert_called_once_with(":warning: Could not resume workflow: missing workflow run ID.")
+
+
+def test_resume_workflow_after_action_warns_when_saved_state_missing(mocker):
+    respond = mocker.Mock()
+    workflow = mocker.Mock()
+    load_state = mocker.patch.object(workflow_bridge, "load_state_from_store", return_value=None)
+
+    workflow_bridge.resume_workflow_after_action("workflow-run-123", respond, workflow)
+
+    load_state.assert_called_once_with("workflow-run-123")
+    workflow.workflow.stream.assert_not_called()
+    respond.assert_called_once_with(":warning: Could not resume workflow: saved state was not found.")
+
+
+def test_resume_workflow_after_action_streams_and_saves_final_state(mocker):
+    respond = mocker.Mock()
+    workflow = mocker.Mock()
+    saved_state = GmailAgentState(
+        user_id="U090QS5DDEE",
+        workflow_run_id="workflow-run-123",
+        awaiting_approval=True,
+    )
+    final_state = saved_state.model_copy(update={"awaiting_approval": False, "workflow_complete": True})
+    load_state = mocker.patch.object(workflow_bridge, "load_state_from_store", return_value=saved_state)
+    save_state = mocker.patch.object(workflow_bridge, "save_state_to_store")
+    workflow.workflow.stream.return_value = [final_state]
+
+    workflow_bridge.resume_workflow_after_action("workflow-run-123", respond, workflow)
+
+    load_state.assert_called_once_with("workflow-run-123")
+    workflow.workflow.stream.assert_called_once()
+    streamed_state = workflow.workflow.stream.call_args.args[0]
+    assert streamed_state.awaiting_approval is False
+    assert streamed_state.current_draft_index == 1
+    save_state.assert_called_once_with(final_state)
+    respond.assert_called_once_with("✅ Workflow completed successfully!")

--- a/tests/workflows/test_state_manager.py
+++ b/tests/workflows/test_state_manager.py
@@ -1,0 +1,26 @@
+from src.models.agent_schemas import GmailAgentState
+from src.workflows.state_manager import StateManager
+
+VALID_SLACK_USER_ID = "U090QS5DDEE"
+
+
+def test_memory_store_keys_state_by_workflow_run_id_not_user_id():
+    state_manager = StateManager(storage_backend="memory")
+    first_run = GmailAgentState(user_id=VALID_SLACK_USER_ID, workflow_run_id="workflow-run-1")
+    second_run = GmailAgentState(user_id=VALID_SLACK_USER_ID, workflow_run_id="workflow-run-2")
+
+    state_manager.save_state(first_run)
+    state_manager.save_state(second_run)
+
+    assert state_manager.load_state("workflow-run-1") == first_run
+    assert state_manager.load_state("workflow-run-2") == second_run
+
+
+def test_memory_store_does_not_fall_back_to_user_id_for_unknown_workflow_run():
+    state_manager = StateManager(storage_backend="memory")
+    state = GmailAgentState(user_id=VALID_SLACK_USER_ID, workflow_run_id="workflow-run-1")
+
+    state_manager.save_state(state)
+
+    assert state_manager.load_state("hallucinated-workflow-run") is None
+    assert state_manager.load_state(VALID_SLACK_USER_ID) is None


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #61 

#### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Maintenance / cleanup
- [ ] Test-only change
- [x] Breaking change
- [ ] Documentation only

#### What does this implement/fix? Explain your changes.
This fixes workflow state persistence so concurrent workflow runs for the same Slack user no longer overwrite each other.
Previously, `GmailAgentState.workflow_run_id` existed, but persisted state was keyed by `user_id`. That meant a second workflow run for the same user silently replaced the first saved run. `/resume_workflow` also loaded by `user_id`, so callers could not target a specific paused workflow.
This change makes workflow runs independently addressable:
- `StateManager` saves and loads state by `workflow_run_id`.
- `/start_workflow` returns `workflow_run_id` in paused and completed responses.
- `/resume_workflow` now requires `workflow_run_id` and resumes that specific run.
- Slack draft approval buttons now carry `workflow_run_id`.
- Slack action resume loads saved state by `workflow_run_id` instead of Slack `user_id`.
- Missing or malformed Slack workflow run IDs produce a warning instead of falling back to `user_id`.

This is marked as a breaking change because `/resume_workflow` now requires `workflow_run_id` in the request body.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Confirm `StateManager` no longer keys saved workflow state by Slack `user_id`.
- Confirm `/start_workflow` returns enough information for callers to resume the correct run.
- Confirm `/resume_workflow` uses `workflow_run_id` and does not accidentally fall back to `user_id`.
- Confirm Slack button values safely carry and extract `workflow_run_id`.
- Confirm malformed or old Slack button values do not hallucinate a workflow run ID.

#### Did you add any tests for the change?
Yes. Added and updated tests for:
- `StateManager` storing multiple runs for the same user independently.
- Unknown or hallucinated workflow run IDs not falling back to `user_id`.
- `GmailAgentState` using `workflow_run_id` instead of legacy `thread_id`.
- `/start_workflow` returning `workflow_run_id`.
- `/resume_workflow` requiring and loading by `workflow_run_id`.
- Slack action values carrying `workflow_run_id`.
- Slack action parsing rejecting old or malformed values.
- Slack workflow resume warnings for missing or missing-state workflow IDs.
- Slack workflow resume happy path streaming and saving final state.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [SEC], or [BREAKING]
    - [BUG] - bugfix
    - [MNT] - CI, test framework, dependency updates
    - [ENH] - adding or improving code
    - [DOC] - writing or improving documentation or docstrings
    - [SEC] - security fixes or vulnerability patches
    - [BREAKING] - any change that requires user to update their setup or code 
- [x] Tests added or updated for changed behavior, or explained why not needed
- [x] No secrets, credentials, or `.env` values committed
- [x] `pyproject.toml` updated if new dependencies were added and `uv.lock` regenerated via `uv sync`