### PR TITLE
Fix/gmail writer thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.2.1] — 2026-05-09
+
+### Fixed
+- Preserved Gmail `threadId` when creating, saving, and sending draft replies so workflow-generated responses stay attached to the original Gmail conversation.
+
+### Maintenance
+- Added focused Gmail writer, workflow handoff, and tool schema tests for threaded draft/reply behavior.
+
+---
+
 ## [0.2.0] — 2026-05-08
 
 ### Breaking Changed

--- a/src/gmail/gmail_writer.py
+++ b/src/gmail/gmail_writer.py
@@ -1,4 +1,5 @@
 import base64
+import logging
 import mimetypes
 import os
 from email import message_from_bytes
@@ -10,6 +11,8 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
 from .gmail_authenticator import auth_user
+
+logger = logging.getLogger(__name__)
 
 
 class GmailWriter:
@@ -50,6 +53,7 @@ class GmailWriter:
         subject: str,
         message: str,
         attachment_path: Optional[str] = None,
+        thread_id: Optional[str] = None,
     ) -> Optional[dict]:
         """
         Create a draft email message dictionary given the sender, recipient, subject, message,
@@ -61,6 +65,7 @@ class GmailWriter:
             subject (str): The subject line of the email.
             message (str): The body of the email.
             attachment_path (Optional[str], optional): The path to the attachment. Defaults to None.
+            thread_id (Optional[str], optional): Gmail thread ID to attach the draft to. Defaults to None.
 
         Returns:
             Optional[dict]: The encoded draft email message.
@@ -97,9 +102,14 @@ class GmailWriter:
             raw_bytes = base64.urlsafe_b64encode(draft.as_bytes())
             raw_str = raw_bytes.decode()
 
-            return {"raw": raw_str}
+            draft_body = {"raw": raw_str}
+            if thread_id:
+                draft_body["threadId"] = thread_id
+
+            return draft_body
 
         except HttpError as error:
+            logger.exception("Error creating Gmail draft")
             print(f"An error occurred: {error}")
             return None
 
@@ -127,6 +137,7 @@ class GmailWriter:
         """
         send_message = self.service.users().messages().send(userId="me", body=draft).execute()
         print("Message issued successfully")
+        logger.info("Gmail message sent successfully")
 
         return send_message
 
@@ -171,12 +182,17 @@ class GmailWriter:
         raw_message = base64.urlsafe_b64encode(message.as_bytes()).decode()
 
         try:
-            message = self.service.users().messages().send(userId="me", body=raw_message).execute()
+            body = {"raw": raw_message}
+            if original_message.get("threadId"):
+                body["threadId"] = original_message["threadId"]
+
+            message = self.service.users().messages().send(userId="me", body=body).execute()
             print(f"Reply sent successfully! Message ID: {message['id']}")
+            logger.info("Gmail reply sent successfully with message_id=%s", message["id"])
             return message
 
-        except HttpError as error:
-            print(f"An error occurred while sending reply: {error}")
+        except HttpError:
+            logger.exception("Error sending Gmail reply")
             return None
 
     def save_draft(self, draft):
@@ -191,12 +207,15 @@ class GmailWriter:
         """
         try:
             create_draft = {"message": {"raw": draft["raw"]}}
+            if draft.get("threadId"):
+                create_draft["message"]["threadId"] = draft["threadId"]
 
             saved_draft = self.service.users().drafts().create(userId="me", body=create_draft).execute()
             print(f"Draft saved successfully with ID: {saved_draft.get('id', 'N/A')}")
+            logger.info("Gmail draft saved successfully with draft_id=%s", saved_draft.get("id", "N/A"))
             return saved_draft
-        except HttpError as error:
-            print(f"An error occurred while saving draft: {error}")
+        except HttpError:
+            logger.exception("Error saving Gmail draft")
             return None
 
     def _email_message_decoder(self, raw_str):

--- a/src/models/gmail.py
+++ b/src/models/gmail.py
@@ -189,6 +189,10 @@ class GmailToolFunction:
                     "subject": ParamProperties(type="string", description="The subject of the email."),
                     "message": ParamProperties(type="string", description="The main content of the email."),
                     "attachment_path": ParamProperties(type="string", description="Path to attachment - Optional"),
+                    "thread_id": ParamProperties(
+                        type="string",
+                        description="Gmail thread ID to attach this draft to - Optional",
+                    ),
                 },
                 required=["sender", "recipient", "subject", "message"],
             ),

--- a/src/workflows/workflow.py
+++ b/src/workflows/workflow.py
@@ -302,6 +302,7 @@ class EmailProcessingWorkflow:
                         recipient=email.from_email,
                         subject=f"Re: {email.subject}",
                         message=draft_content,
+                        thread_id=email.thread_id,
                     )
 
                     draft_responses.append(

--- a/tests/agent/test_agent_schemas.py
+++ b/tests/agent/test_agent_schemas.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 from pydantic import ValidationError
 from src.models.agent_schemas import AgentSchema, GmailAgentState
+from src.models.gmail import GmailToolFunction
 
 
 def test_agent_schema_uses_openrouter_api_key():
@@ -49,3 +50,11 @@ def test_gmail_agent_state_rejects_legacy_thread_id_without_workflow_run_id():
         GmailAgentState(user_id="U090QS5DDEE", thread_id="legacy-thread-id")
 
     assert any(err["loc"] == ("workflow_run_id",) for err in exc_info.value.errors())
+
+
+def test_create_draft_schema_exposes_optional_thread_id():
+    """Agent tool schema should let create_draft attach drafts to Gmail threads."""
+    schema = GmailToolFunction.generate_create_draft_schema()
+
+    assert schema.parameters.properties["thread_id"].type == "string"
+    assert "thread_id" not in schema.parameters.required

--- a/tests/gmail/test_gmail_writer.py
+++ b/tests/gmail/test_gmail_writer.py
@@ -1,0 +1,105 @@
+import base64
+from email import message_from_bytes
+from email.policy import default
+
+import pytest
+from src.gmail.gmail_writer import GmailWriter
+
+THREAD_ID = "thread_active_123"
+
+
+@pytest.fixture
+def writer(mocker):
+    """Build a GmailWriter with auth and Gmail API client mocked out."""
+    mocker.patch("src.gmail.gmail_writer.auth_user", return_value=mocker.Mock())
+    mocker.patch("src.gmail.gmail_writer.build", return_value=mocker.Mock())
+    return GmailWriter(token_path="/fake/tokens/")
+
+
+def _decode_raw_message(raw_message):
+    return message_from_bytes(base64.urlsafe_b64decode(raw_message), policy=default)
+
+
+def test_create_draft_includes_thread_id_even_when_subject_changes(writer):
+    """create_draft should keep changed subjects while adding Gmail thread metadata."""
+    draft = writer.create_draft(
+        sender="me@example.com",
+        recipient="them@example.com",
+        subject="Re: lol",
+        message="Still replying in the active Gmail thread.",
+        thread_id=THREAD_ID,
+    )
+
+    decoded = _decode_raw_message(draft["raw"])
+
+    assert draft["threadId"] == THREAD_ID
+    assert decoded["Subject"] == "Re: lol"
+    assert decoded["To"] == "them@example.com"
+    assert decoded.get_body(preferencelist=("plain",)).get_content() == "Still replying in the active Gmail thread.\n"
+
+
+def test_save_draft_passes_thread_id_to_gmail(writer):
+    """save_draft should pass threadId through to Gmail drafts.create."""
+    draft = {"raw": "encoded-message", "threadId": THREAD_ID}
+    writer.service.users.return_value.drafts.return_value.create.return_value.execute.return_value = {"id": "draft-1"}
+
+    writer.save_draft(draft)
+
+    create_kwargs = writer.service.users.return_value.drafts.return_value.create.call_args.kwargs
+    assert create_kwargs["body"] == {"message": {"raw": "encoded-message", "threadId": THREAD_ID}}
+
+
+def test_standalone_drafts_do_not_include_thread_id(writer):
+    """Drafts created without thread_id should remain standalone Gmail drafts."""
+    draft = writer.create_draft(
+        sender="me@example.com",
+        recipient="them@example.com",
+        subject="New topic",
+        message="This is not a threaded reply.",
+    )
+    writer.service.users.return_value.drafts.return_value.create.return_value.execute.return_value = {"id": "draft-1"}
+
+    writer.save_draft(draft)
+
+    assert "threadId" not in draft
+    create_kwargs = writer.service.users.return_value.drafts.return_value.create.call_args.kwargs
+    assert create_kwargs["body"] == {"message": {"raw": draft["raw"]}}
+
+
+def test_send_draft_preserves_thread_id_in_gmail_send_body(writer):
+    """send_draft must not drop threadId before calling Gmail messages.send."""
+    draft = {"raw": "encoded-message", "threadId": THREAD_ID}
+    writer.service.users.return_value.messages.return_value.send.return_value.execute.return_value = {"id": "sent-1"}
+
+    writer.send_draft(draft)
+
+    send_kwargs = writer.service.users.return_value.messages.return_value.send.call_args.kwargs
+    assert send_kwargs["body"] == draft
+
+
+def test_send_reply_uses_thread_id_when_recipient_changed_subject(writer):
+    """send_reply should use threadId even when the prior message subject changed."""
+    original_message = {
+        "threadId": THREAD_ID,
+        "payload": {
+            "headers": [
+                {"name": "From", "value": "them@example.com"},
+                {"name": "To", "value": "me@example.com"},
+                {"name": "Subject", "value": "lol"},
+                {"name": "Message-ID", "value": "<message-123@example.com>"},
+            ]
+        },
+    }
+    writer.service.users.return_value.messages.return_value.send.return_value.execute.return_value = {"id": "reply-1"}
+
+    writer.send_reply(original_message, "Yep, still part of this thread.")
+
+    send_kwargs = writer.service.users.return_value.messages.return_value.send.call_args.kwargs
+    assert send_kwargs["body"]["threadId"] == THREAD_ID
+
+    decoded = _decode_raw_message(send_kwargs["body"]["raw"])
+    assert decoded["Subject"] == "Re: lol"
+    assert decoded["To"] == "them@example.com"
+    assert decoded["In-Reply-To"] == "<message-123@example.com>"
+    assert decoded["References"] == "<message-123@example.com>"
+    assert decoded.get_body(preferencelist=("plain",)).get_content() == "Yep, still part of this thread.\n"

--- a/tests/workflows/test_create_draft_responses.py
+++ b/tests/workflows/test_create_draft_responses.py
@@ -1,0 +1,67 @@
+from unittest.mock import patch
+
+import pytest
+from src.agent.agent import Agent
+from src.gmail.gmail_reader import GmailReader
+from src.gmail.gmail_writer import GmailWriter
+from src.models.agent_schemas import GmailAgentState
+from src.models.gmail import EmailMessage
+from src.slack_handlers.draft_approval_handler import DraftApprovalHandler
+from src.workflows.workflow import EmailProcessingWorkflow
+
+
+@pytest.fixture
+def workflow(mocker):
+    """EmailProcessingWorkflow with all external dependencies mocked out."""
+    gmail_reader = mocker.Mock(spec=GmailReader)
+    gmail_writer = mocker.Mock(spec=GmailWriter)
+    draft_handler = mocker.Mock(spec=DraftApprovalHandler)
+    agent = mocker.Mock(spec=Agent)
+
+    with patch("openai.OpenAI"):
+        wf = EmailProcessingWorkflow(
+            gmail_reader=gmail_reader,
+            gmail_writer=gmail_writer,
+            draft_handler=draft_handler,
+            agent=agent,
+        )
+    return wf
+
+
+def test_create_draft_responses_passes_original_thread_id(workflow, mocker):
+    """Workflow-created Gmail drafts must retain the original email thread_id."""
+    email = EmailMessage(
+        id="email-1",
+        subject="Meeting tomorrow",
+        from_email="them@example.com",
+        to_email="me@example.com",
+        date="Sat, 09 May 2026 18:00:00 -0700",
+        body="Can we still meet tomorrow?",
+        thread_id="thread-123",
+    )
+    state = GmailAgentState(
+        user_id="U123",
+        workflow_run_id="workflow-123",
+        unread_emails=[email],
+        processed_emails=[
+            {
+                "email_id": email.id,
+                "priority": "High",
+                "response_type": "Reply",
+                "reason": "Needs confirmation",
+            }
+        ],
+    )
+    mocker.patch.object(workflow, "_generate_draft_response", return_value="Yes, see you then.")
+    workflow.gmail_writer.create_draft.return_value = {"raw": "encoded-message", "threadId": email.thread_id}
+
+    result = workflow._create_draft_responses(state)
+
+    workflow.gmail_writer.create_draft.assert_called_once_with(
+        sender=email.to_email,
+        recipient=email.from_email,
+        subject=f"Re: {email.subject}",
+        message="Yes, see you then.",
+        thread_id=email.thread_id,
+    )
+    assert result.draft_responses[0]["draft"]["threadId"] == email.thread_id


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #62.

#### Type of change
- [x] Bug fix
- [ ] New feature
- [x] Maintenance / cleanup
- [ ] Test-only change
- [ ] Breaking change
- [ ] Documentation only

#### What does this implement/fix? Explain your changes.
This fixes Gmail draft/reply threading by preserving Gmail `threadId` through the write path.

Changes include:
- `GmailWriter.create_draft()` now accepts optional `thread_id` and includes it as `threadId` in the returned draft payload.
- `GmailWriter.save_draft()` passes `threadId` through to Gmail `drafts().create()` when present.
- `GmailWriter.send_reply()` includes the original message `threadId` in the Gmail `messages().send()` body.
- `EmailProcessingWorkflow._create_draft_responses()` passes `email.thread_id` when creating replies.
- The `create_draft` tool schema now exposes optional `thread_id`.
- Gmail writer success paths are logged in addition to existing user-facing success prints, and Gmail API errors now use logging.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Whether `threadId` is propagated correctly through `create_draft`, `save_draft`, `send_draft`, and `send_reply`.
- Whether the workflow handoff correctly uses the original `EmailMessage.thread_id`.
- Whether exposing optional `thread_id` in the tool schema is the right contract for agent-driven draft creation.
- Whether the logging changes in `GmailWriter` strike the right balance between user-visible output and application logs.

#### Did you add any tests for the change?
Yes.

Added focused coverage for:
- Gmail writer thread ID preservation.
- Standalone draft backward compatibility when no `thread_id` is supplied.
- Changed-subject replies still carrying Gmail `threadId`.
- Workflow handoff from `EmailMessage.thread_id` into `GmailWriter.create_draft()`.
- Tool schema exposure of optional `thread_id`.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [SEC], or [BREAKING]
    - [BUG] - bugfix
    - [MNT] - CI, test framework, dependency updates
    - [ENH] - adding or improving code
    - [DOC] - writing or improving documentation or docstrings
    - [SEC] - security fixes or vulnerability patches
    - [BREAKING] - any change that requires user to update their setup or code 
- [x] Tests added or updated for changed behavior, or explained why not needed
- [x] No secrets, credentials, or `.env` values committed
- [x] `pyproject.toml` updated if new dependencies were added and `uv.lock` regenerated via `uv sync`