### PR TITLE
[ENH] Removing client-supplied identity from /start_workflow and /resume_workflow.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,16 @@ APP_NAME="Inbox0"
 SLACK_BOT_TOKEN="xoxb-your-bot-token"
 SLACK_SIGNING_SECRET="your-signing-secret"
 
+# Workflow API Auth
+# Required by /start_workflow and /resume_workflow.
+# Send INBOX0_API_KEY as the X-Inbox0-API-Key request header.
+# Generate locally with: openssl rand -hex 32
+INBOX0_API_KEY="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+# Stable label for the Gmail account this API key controls. This can be a nickname or email address.
+INBOX0_GMAIL_ACCOUNT_ID="personal-gmail"
+# Slack member ID that receives draft approval DMs. In Slack: profile -> more actions -> Copy member ID.
+INBOX0_SLACK_USER_ID="U12345678"
+
 #Logging
 LOG_FILE="/absolute/path/to/Inbox0/logs/app.log"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Preserved Gmail `threadId` when creating, saving, and sending draft replies so workflow-generated responses stay attached to the original Gmail conversation.
+- Protected `/start_workflow` and `/resume_workflow` with `X-Inbox0-API-Key` and server-side `gmail_account_id` ownership to prevent client-supplied identity spoofing.
+- Prevented cross-account workflow resume attempts by checking saved workflow state ownership before resuming.
 
 ### Maintenance
+- Renamed workflow identity fields to distinguish authenticated Gmail account ownership from Slack notification routing.
 - Added focused Gmail writer, workflow handoff, and tool schema tests for threaded draft/reply behavior.
+- Expanded route, workflow, and Slack tests for API-key auth, spoofed identity rejection, cross-account resume denial, and hallucinated Slack routing protection.
+- Documented workflow API auth configuration in `.env.example` and `README.md`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ OPENROUTER_BASE_URL=https://openrouter.ai/api/v1  # override for other providers
 LANGSMITH_API_KEY=your-langsmith-api-key # from https://smith.langchain.com — used for LangGraph tracing
 SLACK_BOT_TOKEN=xoxb-...
 SLACK_SIGNING_SECRET=...
+# Protects /start_workflow and /resume_workflow. Generate with: openssl rand -hex 32
+INBOX0_API_KEY=your-generated-workflow-api-key
+# Stable label for the Gmail account this API key controls
+INBOX0_GMAIL_ACCOUNT_ID=personal-gmail
+# Slack member ID that receives draft approval DMs
+INBOX0_SLACK_USER_ID=U12345678
 # Absolute path to the tokens folder that contains Gmail OAuth files (must end with a trailing slash)
 TOKENS_PATH=/absolute/path/to/Inbox0/tokens/
 ```
@@ -122,10 +128,12 @@ uv run python main.py
 ### API endpoints
 
 - POST `/start_workflow`
-  - Body: `{ "user_id": "U123ABC" }` (Slack user ID to DM approval requests)
+  - Header: `X-Inbox0-API-Key: <INBOX0_API_KEY>`
+  - Body: `{}`
   - Starts the LangGraph workflow. Returns `{"status": "paused", "awaiting_approval": true}` when waiting on Slack approval, or `{"status": "completed", ...}` when it finishes in one pass.
 - POST `/resume_workflow`
-  - Body: `{ "user_id": "U123ABC", "action": "approve_draft"|"reject_draft"|"save_draft" }`
+  - Header: `X-Inbox0-API-Key: <INBOX0_API_KEY>`
+  - Body: `{ "workflow_run_id": "workflow-run-id-from-start", "action": "approve_draft"|"reject_draft"|"save_draft" }`
   - Resumes the workflow after a Slack action when needed.
 
 Slack endpoints used by the app
@@ -137,6 +145,9 @@ Slack endpoints used by the app
 
 - `.env` is loaded at runtime. Ensure it exists at the project root before starting the app.
 - `TOKENS_PATH` must be an absolute path and end with a trailing slash. It should contain `credentials.json` and will be where `token.json` is created.
+- `INBOX0_API_KEY` is a local workflow API secret. Generate it with `openssl rand -hex 32` and send it as the `X-Inbox0-API-Key` header when calling protected workflow routes.
+- `INBOX0_GMAIL_ACCOUNT_ID` is a stable server-side label for the Gmail account this API key controls, such as `personal-gmail`.
+- `INBOX0_SLACK_USER_ID` is the Slack member ID that receives draft approval DMs. In Slack, open your profile, choose the more actions menu, then copy your member ID.
 - The Flask server defaults to port `5002`.
 - `LANGSMITH_API_KEY` enables LangGraph tracing via [LangSmith](https://smith.langchain.com). Create a free account, generate an API key, and set `LANGCHAIN_TRACING_V2=true` in your `.env` to activate tracing.
 
@@ -189,7 +200,7 @@ Inbox0/
   <img src="assets/inbox0_workflow_diagram.svg" alt="Inbox Zero Workflow Diagram" width="800" />
 </p>
 
-1. Client calls `/start_workflow` with a Slack `user_id`
+1. Client calls `/start_workflow` with `X-Inbox0-API-Key`
 2. `EmailProcessingWorkflow`:
   - reads unread emails
   - summarizes, analyzes, and drafts responses using your configured LLM (any OpenRouter or OpenAI SDK-compatible model)
@@ -206,7 +217,8 @@ Start workflow
 ```bash
 curl -X POST http://localhost:5002/start_workflow \
   -H 'Content-Type: application/json' \
-  -d '{"user_id":"U123ABC"}'
+  -H "X-Inbox0-API-Key: $INBOX0_API_KEY" \
+  -d '{}'
 ```
 
 Resume after an approval (usually triggered internally from Slack)
@@ -214,7 +226,8 @@ Resume after an approval (usually triggered internally from Slack)
 ```bash
 curl -X POST http://localhost:5002/resume_workflow \
   -H 'Content-Type: application/json' \
-  -d '{"user_id":"U123ABC","action":"approve_draft"}'
+  -H "X-Inbox0-API-Key: $INBOX0_API_KEY" \
+  -d '{"workflow_run_id":"workflow-run-id-from-start","action":"approve_draft"}'
 ```
 
 ### Roadmap

--- a/src/models/agent_schemas.py
+++ b/src/models/agent_schemas.py
@@ -64,7 +64,8 @@ class GmailAgentState(BaseModel):
     """State for Gmail processing workflow"""
 
     # Input
-    user_id: str = Field(..., description="Slack user ID requesting email processing")
+    gmail_account_id: str = Field(..., description="Authenticated Gmail account identifier that owns this workflow")
+    slack_user_id: str = Field(..., description="Slack user ID receiving workflow notifications")
     workflow_run_id: str = Field(
         ...,
         description="Unique ID for this workflow run",

--- a/src/models/slack.py
+++ b/src/models/slack.py
@@ -25,7 +25,7 @@ class SlackToolFunction:
                         type="object",
                         description="The Gmail draft dictionary returned from create_draft() function",
                     ),
-                    "user_id": ParamProperties(
+                    "slack_user_id": ParamProperties(
                         type="string",
                         description="Slack user ID to send approval request to",
                     ),
@@ -34,6 +34,6 @@ class SlackToolFunction:
                         description="Optional channel ID (if not provided, sends DM)",
                     ),
                 },
-                required=["draft", "user_id"],
+                required=["draft", "slack_user_id"],
             ),
         )

--- a/src/routes/web/flask_routes.py
+++ b/src/routes/web/flask_routes.py
@@ -1,4 +1,7 @@
 import uuid
+from dataclasses import dataclass
+from hmac import compare_digest
+from os import getenv
 
 from flask import jsonify, request
 from pydantic import ValidationError
@@ -14,6 +17,29 @@ from src.workflows.state_manager import (
     save_state_to_store,
 )
 
+API_KEY_HEADER = "X-Inbox0-API-Key"
+
+
+@dataclass(frozen=True)
+class AuthenticatedWorkflowUser:
+    gmail_account_id: str
+    slack_user_id: str
+
+
+def _authenticate_workflow_request():
+    expected_api_key = getenv("INBOX0_API_KEY")
+    gmail_account_id = getenv("INBOX0_GMAIL_ACCOUNT_ID")
+    slack_user_id = getenv("INBOX0_SLACK_USER_ID")
+
+    if not expected_api_key or not gmail_account_id or not slack_user_id:
+        return None, (jsonify({"error": "auth_not_configured"}), 500)
+
+    supplied_api_key = request.headers.get(API_KEY_HEADER)
+    if not supplied_api_key or not compare_digest(supplied_api_key, expected_api_key):
+        return None, (jsonify({"error": "unauthorized"}), 401)
+
+    return AuthenticatedWorkflowUser(gmail_account_id=gmail_account_id, slack_user_id=slack_user_id), None
+
 
 def register_flask_routes(app, workflow):
     @app.errorhandler(ValidationError)
@@ -25,10 +51,18 @@ def register_flask_routes(app, workflow):
 
     @app.route("/start_workflow", methods=["POST"])
     def start_workflow():
-        req = StartWorkflowRequest.model_validate(request.get_json(silent=True) or {})
+        authenticated_user, auth_error = _authenticate_workflow_request()
+        if auth_error:
+            return auth_error
+
+        StartWorkflowRequest.model_validate(request.get_json(silent=True) or {})
 
         workflow_run_id = str(uuid.uuid4())
-        initial_state = GmailAgentState(user_id=req.user_id, workflow_run_id=workflow_run_id)
+        initial_state = GmailAgentState(
+            gmail_account_id=authenticated_user.gmail_account_id,
+            slack_user_id=authenticated_user.slack_user_id,
+            workflow_run_id=workflow_run_id,
+        )
 
         result_gen = workflow.workflow.stream(initial_state)
 
@@ -59,6 +93,10 @@ def register_flask_routes(app, workflow):
 
     @app.route("/resume_workflow", methods=["POST"])
     def resume_workflow():
+        authenticated_user, auth_error = _authenticate_workflow_request()
+        if auth_error:
+            return auth_error
+
         req = ResumeWorkflowRequest.model_validate(request.get_json(silent=True) or {})
 
         state = load_state_from_store(req.workflow_run_id)
@@ -77,6 +115,9 @@ def register_flask_routes(app, workflow):
         if isinstance(state, dict):
             actual_state = extract_langgraph_state(state)
             state = GmailAgentState(**actual_state)
+
+        if state.gmail_account_id != authenticated_user.gmail_account_id:
+            return jsonify({"error": "forbidden"}), 403
 
         state.awaiting_approval = False
 

--- a/src/routes/web/schemas.py
+++ b/src/routes/web/schemas.py
@@ -1,9 +1,9 @@
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 SLACK_USER_ID_PATTERN = r"^U[A-Z0-9]{8,}$"
-SLACK_USER_ID_DESCRIPTION = "Slack user ID (e.g. U090QS5DDEE)"
+SLACK_USER_ID_DESCRIPTION = "Slack user ID (e.g. U12345678)"
 
 
 class ResumeAction(str, Enum):
@@ -17,20 +17,13 @@ class ResumeAction(str, Enum):
 class StartWorkflowRequest(BaseModel):
     """Request body for POST /start_workflow."""
 
-    user_id: str = Field(
-        ...,
-        pattern=SLACK_USER_ID_PATTERN,
-        description=SLACK_USER_ID_DESCRIPTION,
-    )
+    model_config = ConfigDict(extra="forbid")
 
 
 class ResumeWorkflowRequest(BaseModel):
     """Request body for POST /resume_workflow."""
 
-    user_id: str = Field(
-        ...,
-        pattern=SLACK_USER_ID_PATTERN,
-        description=SLACK_USER_ID_DESCRIPTION,
-    )
+    model_config = ConfigDict(extra="forbid")
+
     workflow_run_id: str = Field(..., description="Workflow run ID returned by /start_workflow")
     action: ResumeAction = Field(..., description="Action to take on the current draft")

--- a/src/slack_handlers/draft_approval_handler.py
+++ b/src/slack_handlers/draft_approval_handler.py
@@ -46,14 +46,14 @@ class DraftApprovalHandler:
         self.DRAFT_TIMEOUT_HOURS = 24
 
     def send_draft_for_approval(
-        self, draft: Dict, user_id: str, workflow_run_id: Optional[str] = None
+        self, draft: Dict, slack_user_id: str, workflow_run_id: Optional[str] = None
     ) -> Optional[str]:
         """
         Send a draft email for approval with interactive buttons.
 
         parameters:
             draft (Dict): Gmail draft dictionary from create_draft()
-            user_id (str): Slack user ID to send approval request to
+            slack_user_id (str): Slack user ID to send approval request to
             workflow_run_id (Optional[str]): Workflow run ID to resume when the user acts on the draft
 
         Returns:
@@ -68,7 +68,7 @@ class DraftApprovalHandler:
             self.pending_drafts[draft_id] = {
                 "draft": draft,
                 "decoded_draft": decoded_draft,
-                "user_id": user_id,
+                "slack_user_id": slack_user_id,
                 "workflow_run_id": workflow_run_id,
                 "created_at": datetime.now(),
                 "status": "pending",
@@ -79,7 +79,7 @@ class DraftApprovalHandler:
             approval_message = self._create_approval_message(decoded_draft, draft_id, workflow_run_id)
 
             # Send to Slack
-            target = user_id
+            target = slack_user_id
             response = self.slack_app.client.chat_postMessage(
                 channel=target,
                 text=approval_message["text"],

--- a/src/workflows/workflow.py
+++ b/src/workflows/workflow.py
@@ -395,7 +395,7 @@ class EmailProcessingWorkflow:
             if state.draft_responses:
                 summary_parts.append(
                     f"\n📝 *Draft Responses Created*\n{len(state.draft_responses)} draft responses "
-                    "have been created and sent to Slack for your approval."
+                    "were created and reviewed through Slack."
                 )
 
             if state.pending_approvals:

--- a/src/workflows/workflow.py
+++ b/src/workflows/workflow.py
@@ -166,7 +166,6 @@ class EmailProcessingWorkflow:
                 user_prompt=prompt,
                 llm_tool_schema=None,
                 system_message="You are an email assistant that speaks succinctly and professionally.",
-                user_id=state.user_id,
             )
             summary_text = self.agent.process_request(request_schema)
 
@@ -236,7 +235,6 @@ class EmailProcessingWorkflow:
                 system_message=(
                     "You are an email assistant that analyzes emails to determine which ones require a response."
                 ),
-                user_id=state.user_id,
             )
             content = self.agent.process_request(request_schema)
 
@@ -354,7 +352,7 @@ class EmailProcessingWorkflow:
 
         draft_id = self.draft_handler.send_draft_for_approval(
             draft=draft_info["draft"],
-            user_id=state.user_id,
+            slack_user_id=state.slack_user_id,
             workflow_run_id=state.workflow_run_id,
         )
 
@@ -553,11 +551,12 @@ class EmailProcessingWorkflow:
             )
         self._seen_message_ids |= ids_this_step
 
-    def run(self, user_id: str) -> GmailAgentState:
+    def run(self, gmail_account_id: str, slack_user_id: str) -> GmailAgentState:
         """Run the email processing workflow
 
         Args:
-            user_id: string of user id
+            gmail_account_id: Authenticated Gmail account identifier that owns the workflow.
+            slack_user_id: Slack user ID that receives workflow notifications.
 
         Returns:
             GmailAgentState object
@@ -566,7 +565,8 @@ class EmailProcessingWorkflow:
         self._seen_message_ids = set()
 
         initial_state = GmailAgentState(
-            user_id=user_id,
+            gmail_account_id=gmail_account_id,
+            slack_user_id=slack_user_id,
             workflow_run_id=workflow_run_id,
         )
 

--- a/tests/agent/test_agent_schemas.py
+++ b/tests/agent/test_agent_schemas.py
@@ -39,17 +39,37 @@ def test_agent_schema_defaults_app_name_to_inbox0():
 
 
 def test_gmail_agent_state_uses_workflow_run_id_not_thread_id():
-    state = GmailAgentState(user_id="U090QS5DDEE", workflow_run_id="workflow-run-123")
+    state = GmailAgentState(
+        gmail_account_id="gmail-account-123",
+        slack_user_id="U12345678",
+        workflow_run_id="workflow-run-123",
+    )
 
+    assert state.gmail_account_id == "gmail-account-123"
+    assert state.slack_user_id == "U12345678"
     assert state.workflow_run_id == "workflow-run-123"
     assert not hasattr(state, "thread_id")
+    assert not hasattr(state, "user_id")
 
 
 def test_gmail_agent_state_rejects_legacy_thread_id_without_workflow_run_id():
     with pytest.raises(ValidationError) as exc_info:
-        GmailAgentState(user_id="U090QS5DDEE", thread_id="legacy-thread-id")
+        GmailAgentState(
+            gmail_account_id="gmail-account-123",
+            slack_user_id="U12345678",
+            thread_id="legacy-thread-id",
+        )
 
     assert any(err["loc"] == ("workflow_run_id",) for err in exc_info.value.errors())
+
+
+def test_gmail_agent_state_rejects_legacy_user_id_without_explicit_ids():
+    with pytest.raises(ValidationError) as exc_info:
+        GmailAgentState(user_id="U12345678", workflow_run_id="workflow-run-123")
+
+    errors = exc_info.value.errors()
+    assert any(err["loc"] == ("gmail_account_id",) for err in errors)
+    assert any(err["loc"] == ("slack_user_id",) for err in errors)
 
 
 def test_create_draft_schema_exposes_optional_thread_id():

--- a/tests/logging/test_draft_approval_handler_logging.py
+++ b/tests/logging/test_draft_approval_handler_logging.py
@@ -16,7 +16,7 @@ def test_draft_approval_handler_logging(caplog, mocker):
     draft_handler.pending_drafts["test_draft_id"] = {
         "draft": {"id": "draft_123"},
         "decoded_draft": {},
-        "user_id": "test_user_id",
+        "slack_user_id": "test_user_id",
         "status": "pending",
         "slack_message_ts": "1234567890.123456",
         "slack_channel": "C12345",

--- a/tests/routes/test_flask_routes.py
+++ b/tests/routes/test_flask_routes.py
@@ -1,27 +1,30 @@
-"""Tests for the Flask web routes and their request schemas.
+"""Tests for Flask web route authentication and request validation."""
 
-Covers:
-- ``StartWorkflowRequest`` / ``ResumeWorkflowRequest`` pydantic validation
-  (Slack user-id format, required fields, enum-bound action).
-- ``/start_workflow`` returns 400 on schema-invalid payloads via the
-  ``ValidationError`` handler.
-- ``/resume_workflow`` returns 404 when no paused state exists for the
-  given user_id (guard against the previous ``AttributeError`` on
-  ``NoneType``).
-"""
+from unittest.mock import patch
 
 import pytest
 from flask import Flask
 from pydantic import ValidationError
-from src.routes.web.flask_routes import register_flask_routes
-from src.routes.web.schemas import (
-    ResumeAction,
-    ResumeWorkflowRequest,
-    StartWorkflowRequest,
-)
+from src.models.agent_schemas import GmailAgentState
+from src.routes.web.flask_routes import API_KEY_HEADER, register_flask_routes
+from src.routes.web.schemas import ResumeAction, ResumeWorkflowRequest, StartWorkflowRequest
 
-VALID_SLACK_USER_ID = "U090QS5DDEE"
+VALID_API_KEY = "test-api-key"
+VALID_GMAIL_ACCOUNT_ID = "gmail-account-123"
+OTHER_GMAIL_ACCOUNT_ID = "gmail-account-456"
+VALID_SLACK_USER_ID = "U12345678"
 VALID_WORKFLOW_RUN_ID = "workflow-run-123"
+
+AUTH_ENV = {
+    "INBOX0_API_KEY": VALID_API_KEY,
+    "INBOX0_GMAIL_ACCOUNT_ID": VALID_GMAIL_ACCOUNT_ID,
+    "INBOX0_SLACK_USER_ID": VALID_SLACK_USER_ID,
+}
+
+
+def _auth_headers(api_key: str = VALID_API_KEY):
+    """Return auth headers for protected workflow route requests."""
+    return {API_KEY_HEADER: api_key}
 
 
 def _make_client(mocker):
@@ -34,38 +37,22 @@ def _make_client(mocker):
 
 
 class TestStartWorkflowRequestSchema:
-    def test_accepts_valid_slack_user_id(self):
-        req = StartWorkflowRequest(user_id=VALID_SLACK_USER_ID)
-        assert req.user_id == VALID_SLACK_USER_ID
+    def test_accepts_empty_payload(self):
+        """Start payload carries no identity; auth supplies Gmail and Slack IDs."""
+        assert StartWorkflowRequest().model_dump() == {}
 
-    @pytest.mark.parametrize(
-        "bad_user_id",
-        [
-            "",
-            "test-user-123",
-            "u090qs5ddee",
-            "U short",
-            "X090QS5DDEE",
-            "U123",
-        ],
-    )
-    def test_rejects_invalid_user_id(self, bad_user_id):
+    @pytest.mark.parametrize("field", ["user_id", "slack_user_id", "gmail_account_id"])
+    def test_rejects_client_supplied_identity_fields(self, field):
+        """Clients must not supply identity or Slack routing fields in the body."""
         with pytest.raises(ValidationError):
-            StartWorkflowRequest(user_id=bad_user_id)
-
-    def test_rejects_missing_user_id(self):
-        with pytest.raises(ValidationError):
-            StartWorkflowRequest()
+            StartWorkflowRequest.model_validate({field: "spoofed"})
 
 
 class TestResumeWorkflowRequestSchema:
     def test_accepts_valid_payload(self):
-        req = ResumeWorkflowRequest(
-            user_id=VALID_SLACK_USER_ID,
-            workflow_run_id=VALID_WORKFLOW_RUN_ID,
-            action="approve_draft",
-        )
-        assert req.user_id == VALID_SLACK_USER_ID
+        """Resume payload only needs workflow_run_id and action."""
+        req = ResumeWorkflowRequest(workflow_run_id=VALID_WORKFLOW_RUN_ID, action="approve_draft")
+
         assert req.workflow_run_id == VALID_WORKFLOW_RUN_ID
         assert req.action is ResumeAction.APPROVE_DRAFT
 
@@ -78,82 +65,124 @@ class TestResumeWorkflowRequestSchema:
         ],
     )
     def test_accepts_each_resume_action(self, action_value, expected):
-        req = ResumeWorkflowRequest(
-            user_id=VALID_SLACK_USER_ID,
-            workflow_run_id=VALID_WORKFLOW_RUN_ID,
-            action=action_value,
-        )
+        """All supported resume actions validate to the enum."""
+        req = ResumeWorkflowRequest(workflow_run_id=VALID_WORKFLOW_RUN_ID, action=action_value)
         assert req.action is expected
 
     def test_rejects_unknown_action(self):
+        """Unknown resume actions are rejected before workflow state changes."""
         with pytest.raises(ValidationError):
-            ResumeWorkflowRequest(
-                user_id=VALID_SLACK_USER_ID,
-                workflow_run_id=VALID_WORKFLOW_RUN_ID,
-                action="delete_everything",
+            ResumeWorkflowRequest(workflow_run_id=VALID_WORKFLOW_RUN_ID, action="delete_everything")
+
+    @pytest.mark.parametrize("field", ["user_id", "slack_user_id", "gmail_account_id"])
+    def test_rejects_client_supplied_identity_fields(self, field):
+        """Resume requests cannot spoof owner or routing identity."""
+        with pytest.raises(ValidationError):
+            ResumeWorkflowRequest.model_validate(
+                {
+                    "workflow_run_id": VALID_WORKFLOW_RUN_ID,
+                    "action": "approve_draft",
+                    field: "spoofed",
+                }
             )
 
-    def test_rejects_invalid_user_id(self):
-        with pytest.raises(ValidationError):
-            ResumeWorkflowRequest(
-                user_id="test-user-123",
-                workflow_run_id=VALID_WORKFLOW_RUN_ID,
-                action="approve_draft",
-            )
+
+class TestWorkflowRouteAuth:
+    def test_missing_api_key_returns_401(self, mocker):
+        """Protected workflow routes require X-Inbox0-API-Key."""
+        client, workflow = _make_client(mocker)
+
+        with patch.dict("os.environ", AUTH_ENV):
+            response = client.post("/start_workflow", json={})
+
+        assert response.status_code == 401
+        assert response.get_json()["error"] == "unauthorized"
+        workflow.workflow.stream.assert_not_called()
+
+    def test_invalid_api_key_returns_401(self, mocker):
+        """Invalid API keys cannot start workflows."""
+        client, workflow = _make_client(mocker)
+
+        with patch.dict("os.environ", AUTH_ENV):
+            response = client.post("/start_workflow", json={}, headers=_auth_headers("wrong-key"))
+
+        assert response.status_code == 401
+        assert response.get_json()["error"] == "unauthorized"
+        workflow.workflow.stream.assert_not_called()
+
+    def test_missing_auth_config_returns_500(self, mocker):
+        """Server must be configured with API key, Gmail account ID, and Slack user ID."""
+        client, workflow = _make_client(mocker)
+
+        with patch.dict("os.environ", {}, clear=True):
+            response = client.post("/start_workflow", json={}, headers=_auth_headers())
+
+        assert response.status_code == 500
+        assert response.get_json()["error"] == "auth_not_configured"
+        workflow.workflow.stream.assert_not_called()
 
 
 class TestStartWorkflowRoute:
-    def test_invalid_user_id_returns_400(self, mocker):
+    def test_rejects_spoofed_identity_fields(self, mocker):
+        """Body-supplied identity fields are rejected even with valid auth."""
         client, workflow = _make_client(mocker)
 
-        response = client.post("/start_workflow", json={"user_id": "test-user-123"})
-
-        assert response.status_code == 400
-        body = response.get_json()
-        assert body["error"] == "invalid_request"
-        assert any(err["loc"] == ["user_id"] for err in body["details"])
-        workflow.workflow.stream.assert_not_called()
-
-    def test_missing_body_returns_400(self, mocker):
-        client, workflow = _make_client(mocker)
-
-        response = client.post("/start_workflow", json={})
+        with patch.dict("os.environ", AUTH_ENV):
+            response = client.post(
+                "/start_workflow",
+                json={"user_id": "attacker", "gmail_account_id": OTHER_GMAIL_ACCOUNT_ID},
+                headers=_auth_headers(),
+            )
 
         assert response.status_code == 400
         assert response.get_json()["error"] == "invalid_request"
         workflow.workflow.stream.assert_not_called()
 
     def test_completed_response_includes_workflow_run_id(self, mocker):
+        """Start route builds state from verified API-key mapping."""
         client, workflow = _make_client(mocker)
         mocker.patch("src.routes.web.flask_routes.uuid.uuid4", return_value=VALID_WORKFLOW_RUN_ID)
         save_state = mocker.patch("src.routes.web.flask_routes.save_state_to_store")
         workflow.workflow.stream.return_value = [
-            {"done": {"user_id": VALID_SLACK_USER_ID, "workflow_run_id": VALID_WORKFLOW_RUN_ID}},
+            {
+                "done": {
+                    "gmail_account_id": VALID_GMAIL_ACCOUNT_ID,
+                    "slack_user_id": VALID_SLACK_USER_ID,
+                    "workflow_run_id": VALID_WORKFLOW_RUN_ID,
+                }
+            },
         ]
 
-        response = client.post("/start_workflow", json={"user_id": VALID_SLACK_USER_ID})
+        with patch.dict("os.environ", AUTH_ENV):
+            response = client.post("/start_workflow", json={}, headers=_auth_headers())
 
         assert response.status_code == 200
         body = response.get_json()
         assert body["status"] == "completed"
         assert body["workflow_run_id"] == VALID_WORKFLOW_RUN_ID
+        initial_state = workflow.workflow.stream.call_args.args[0]
+        assert initial_state.gmail_account_id == VALID_GMAIL_ACCOUNT_ID
+        assert initial_state.slack_user_id == VALID_SLACK_USER_ID
         save_state.assert_called_once()
 
     def test_paused_response_includes_workflow_run_id(self, mocker):
+        """Paused start responses still return the workflow_run_id for later resume."""
         client, workflow = _make_client(mocker)
         mocker.patch("src.routes.web.flask_routes.uuid.uuid4", return_value=VALID_WORKFLOW_RUN_ID)
         save_state = mocker.patch("src.routes.web.flask_routes.save_state_to_store")
         workflow.workflow.stream.return_value = [
             {
                 "paused": {
-                    "user_id": VALID_SLACK_USER_ID,
+                    "gmail_account_id": VALID_GMAIL_ACCOUNT_ID,
+                    "slack_user_id": VALID_SLACK_USER_ID,
                     "workflow_run_id": VALID_WORKFLOW_RUN_ID,
                     "awaiting_approval": True,
                 }
             },
         ]
 
-        response = client.post("/start_workflow", json={"user_id": VALID_SLACK_USER_ID})
+        with patch.dict("os.environ", AUTH_ENV):
+            response = client.post("/start_workflow", json={}, headers=_auth_headers())
 
         assert response.status_code == 200
         body = response.get_json()
@@ -165,16 +194,15 @@ class TestStartWorkflowRoute:
 
 class TestResumeWorkflowRoute:
     def test_invalid_action_returns_400(self, mocker):
+        """Invalid actions are rejected before loading or mutating workflow state."""
         client, workflow = _make_client(mocker)
 
-        response = client.post(
-            "/resume_workflow",
-            json={
-                "user_id": VALID_SLACK_USER_ID,
-                "workflow_run_id": VALID_WORKFLOW_RUN_ID,
-                "action": "delete_everything",
-            },
-        )
+        with patch.dict("os.environ", AUTH_ENV):
+            response = client.post(
+                "/resume_workflow",
+                json={"workflow_run_id": VALID_WORKFLOW_RUN_ID, "action": "delete_everything"},
+                headers=_auth_headers(),
+            )
 
         assert response.status_code == 400
         body = response.get_json()
@@ -183,20 +211,16 @@ class TestResumeWorkflowRoute:
         workflow.workflow.stream.assert_not_called()
 
     def test_returns_404_when_no_paused_workflow(self, mocker):
+        """Unknown workflow_run_id returns 404 after request auth succeeds."""
         client, workflow = _make_client(mocker)
-        load_state = mocker.patch(
-            "src.routes.web.flask_routes.load_state_from_store",
-            return_value=None,
-        )
+        load_state = mocker.patch("src.routes.web.flask_routes.load_state_from_store", return_value=None)
 
-        response = client.post(
-            "/resume_workflow",
-            json={
-                "user_id": VALID_SLACK_USER_ID,
-                "workflow_run_id": VALID_WORKFLOW_RUN_ID,
-                "action": "approve_draft",
-            },
-        )
+        with patch.dict("os.environ", AUTH_ENV):
+            response = client.post(
+                "/resume_workflow",
+                json={"workflow_run_id": VALID_WORKFLOW_RUN_ID, "action": "approve_draft"},
+                headers=_auth_headers(),
+            )
 
         assert response.status_code == 404
         body = response.get_json()
@@ -204,3 +228,27 @@ class TestResumeWorkflowRoute:
         assert VALID_WORKFLOW_RUN_ID in body["message"]
         load_state.assert_called_once_with(VALID_WORKFLOW_RUN_ID)
         workflow.workflow.stream.assert_not_called()
+
+    def test_cross_gmail_account_resume_returns_403(self, mocker):
+        """A valid API key cannot resume workflow state owned by another Gmail account."""
+        client, workflow = _make_client(mocker)
+        saved_state = GmailAgentState(
+            gmail_account_id=OTHER_GMAIL_ACCOUNT_ID,
+            slack_user_id=VALID_SLACK_USER_ID,
+            workflow_run_id=VALID_WORKFLOW_RUN_ID,
+            awaiting_approval=True,
+        )
+        mocker.patch("src.routes.web.flask_routes.load_state_from_store", return_value=saved_state)
+        save_state = mocker.patch("src.routes.web.flask_routes.save_state_to_store")
+
+        with patch.dict("os.environ", AUTH_ENV):
+            response = client.post(
+                "/resume_workflow",
+                json={"workflow_run_id": VALID_WORKFLOW_RUN_ID, "action": "approve_draft"},
+                headers=_auth_headers(),
+            )
+
+        assert response.status_code == 403
+        assert response.get_json()["error"] == "forbidden"
+        workflow.workflow.stream.assert_not_called()
+        save_state.assert_not_called()

--- a/tests/routes/test_slack_routes_validation.py
+++ b/tests/routes/test_slack_routes_validation.py
@@ -25,7 +25,7 @@ from src.routes.integrations_slack.slack_routes import (
     register_slack_routes,
 )
 
-VALID_SLACK_USER_ID = "U090QS5DDEE"
+VALID_SLACK_USER_ID = "U12345678"
 VALID_WORKFLOW_RUN_ID = "workflow-run-123"
 
 

--- a/tests/slack_handlers/test_workflow_bridge.py
+++ b/tests/slack_handlers/test_workflow_bridge.py
@@ -30,7 +30,8 @@ def test_resume_workflow_after_action_streams_and_saves_final_state(mocker):
     respond = mocker.Mock()
     workflow = mocker.Mock()
     saved_state = GmailAgentState(
-        user_id="U090QS5DDEE",
+        gmail_account_id="gmail-account-123",
+        slack_user_id="U12345678",
         workflow_run_id="workflow-run-123",
         awaiting_approval=True,
     )

--- a/tests/workflows/test_create_draft_responses.py
+++ b/tests/workflows/test_create_draft_responses.py
@@ -40,7 +40,8 @@ def test_create_draft_responses_passes_original_thread_id(workflow, mocker):
         thread_id="thread-123",
     )
     state = GmailAgentState(
-        user_id="U123",
+        gmail_account_id="gmail-account-123",
+        slack_user_id="U12345678",
         workflow_run_id="workflow-123",
         unread_emails=[email],
         processed_emails=[

--- a/tests/workflows/test_create_draft_responses.py
+++ b/tests/workflows/test_create_draft_responses.py
@@ -66,3 +66,34 @@ def test_create_draft_responses_passes_original_thread_id(workflow, mocker):
         thread_id=email.thread_id,
     )
     assert result.draft_responses[0]["draft"]["threadId"] == email.thread_id
+
+
+def test_hallucinated_slack_user_id_does_not_change_draft_routing(workflow, mocker):
+    """LLM-derived draft metadata must not override the authenticated Slack route."""
+    save_state = mocker.patch("src.workflows.workflow.save_state_to_store")
+    workflow.draft_handler.send_draft_for_approval.return_value = "draft-123"
+    state = GmailAgentState(
+        gmail_account_id="gmail-account-123",
+        slack_user_id="U12345678",
+        workflow_run_id="workflow-123",
+        draft_responses=[
+            {
+                "email_id": "email-1",
+                "draft": {"raw": "encoded-message"},
+                "priority": "High",
+                "draft_content": "Looks good.",
+                "slack_user_id": "UATTACKER1",
+            }
+        ],
+    )
+
+    result = workflow._send_drafts_to_slack(state)
+
+    workflow.draft_handler.send_draft_for_approval.assert_called_once_with(
+        draft={"raw": "encoded-message"},
+        slack_user_id="U12345678",
+        workflow_run_id="workflow-123",
+    )
+    assert result.awaiting_approval is True
+    assert result.current_draft_id == "draft-123"
+    save_state.assert_called_once_with(result)

--- a/tests/workflows/test_read_unread_emails.py
+++ b/tests/workflows/test_read_unread_emails.py
@@ -40,7 +40,11 @@ def workflow(mocker):
 
 class TestReadUnreadEmails:
     def _make_state(self):
-        return GmailAgentState(user_id="test_user", workflow_run_id="test_workflow_run")
+        return GmailAgentState(
+            gmail_account_id="gmail-account-123",
+            slack_user_id="U12345678",
+            workflow_run_id="test_workflow_run",
+        )
 
     def _setup_mocks(self, workflow, multi_thread_inbox):
         """

--- a/tests/workflows/test_redundancy_detection.py
+++ b/tests/workflows/test_redundancy_detection.py
@@ -152,6 +152,6 @@ class TestDetectCrossStepDuplicates:
         workflow._seen_message_ids = {"msg_from_previous_run"}
 
         workflow.workflow.stream = lambda state, **kwargs: iter([{}])
-        workflow.run(user_id="test_user")
+        workflow.run(gmail_account_id="gmail-account-123", slack_user_id="U12345678")
 
         assert "msg_from_previous_run" not in workflow._seen_message_ids

--- a/tests/workflows/test_state_manager.py
+++ b/tests/workflows/test_state_manager.py
@@ -1,13 +1,22 @@
 from src.models.agent_schemas import GmailAgentState
 from src.workflows.state_manager import StateManager
 
-VALID_SLACK_USER_ID = "U090QS5DDEE"
+VALID_SLACK_USER_ID = "U12345678"
+VALID_GMAIL_ACCOUNT_ID = "gmail-account-123"
 
 
 def test_memory_store_keys_state_by_workflow_run_id_not_user_id():
     state_manager = StateManager(storage_backend="memory")
-    first_run = GmailAgentState(user_id=VALID_SLACK_USER_ID, workflow_run_id="workflow-run-1")
-    second_run = GmailAgentState(user_id=VALID_SLACK_USER_ID, workflow_run_id="workflow-run-2")
+    first_run = GmailAgentState(
+        gmail_account_id=VALID_GMAIL_ACCOUNT_ID,
+        slack_user_id=VALID_SLACK_USER_ID,
+        workflow_run_id="workflow-run-1",
+    )
+    second_run = GmailAgentState(
+        gmail_account_id=VALID_GMAIL_ACCOUNT_ID,
+        slack_user_id=VALID_SLACK_USER_ID,
+        workflow_run_id="workflow-run-2",
+    )
 
     state_manager.save_state(first_run)
     state_manager.save_state(second_run)
@@ -18,7 +27,11 @@ def test_memory_store_keys_state_by_workflow_run_id_not_user_id():
 
 def test_memory_store_does_not_fall_back_to_user_id_for_unknown_workflow_run():
     state_manager = StateManager(storage_backend="memory")
-    state = GmailAgentState(user_id=VALID_SLACK_USER_ID, workflow_run_id="workflow-run-1")
+    state = GmailAgentState(
+        gmail_account_id=VALID_GMAIL_ACCOUNT_ID,
+        slack_user_id=VALID_SLACK_USER_ID,
+        workflow_run_id="workflow-run-1",
+    )
 
     state_manager.save_state(state)
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #69.

#### Type of change
- [x] Bug fix
- [ ] New feature
- [x] Maintenance / cleanup
- [ ] Test-only change
- [ ] Breaking change
- [x] Documentation only

#### What does this implement/fix? Explain your changes.
This fixes an IDOR/broken-authentication issue in the workflow routes by removing client-supplied identity from `/start_workflow` and `/resume_workflow`.

Changes include:
- Protected workflow routes with `X-Inbox0-API-Key`.
- Added server-side workflow auth config:
  - `INBOX0_API_KEY`
  - `INBOX0_GMAIL_ACCOUNT_ID`
  - `INBOX0_SLACK_USER_ID`
- Replaced ambiguous workflow `user_id` state with explicit `gmail_account_id` and `slack_user_id`.
- Ensured saved workflow state is owned by `gmail_account_id`.
- Added cross-account resume protection so a valid API key cannot resume another Gmail account’s workflow.
- Prevented request body spoofing of `user_id`, `gmail_account_id`, or `slack_user_id`.
- Updated Slack draft approval routing to use `slack_user_id` explicitly.
- Updated `.env.example` and README instructions for the new workflow API auth model.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Whether the API-key auth boundary is appropriate for the current local/self-hosted workflow.
- Whether `gmail_account_id` and `slack_user_id` are clearly separated across route state, workflow state, and Slack routing.
- Whether `/resume_workflow` correctly denies cross-account workflow resume attempts.
- Whether request schemas reject all caller-supplied identity/routing fields.
- Whether README and `.env.example` make the new setup clear.

#### Did you add any tests for the change?
Yes.

Added or updated tests for:
- Missing API key.
- Invalid API key.
- Missing auth configuration.
- Request body spoofing of `user_id`, `gmail_account_id`, and `slack_user_id`.
- Cross-account workflow resume denial.
- Explicit `gmail_account_id` / `slack_user_id` workflow state.
- LLM-hallucinated `slack_user_id` not overriding authenticated Slack routing.
- Updated stale workflow, state manager, Slack route, and Slack handler tests.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [SEC], or [BREAKING]
    - [BUG] - bugfix
    - [MNT] - CI, test framework, dependency updates
    - [ENH] - adding or improving code
    - [DOC] - writing or improving documentation or docstrings
    - [SEC] - security fixes or vulnerability patches
    - [BREAKING] - any change that requires user to update their setup or code 
- [x] Tests added or updated for changed behavior, or explained why not needed
- [x] No secrets, credentials, or `.env` values committed
- [x] `pyproject.toml` updated if new dependencies were added and `uv.lock` regenerated via `uv sync`