### PR TITLE
[ENH] Enforce OpenRouter ZDR and Deny Data Collection Requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ EMAIL_SALUTATION="Hello {name},"
 EMAIL_SIGNOFF=""
 
 #LangSmith
-LANGSMITH_TRACING="true"
+LANGSMITH_TRACING="false"
 LANGSMITH_ENDPOINT="https://api.smith.langchain.com"
 LANGSMITH_API_KEY="lsv2_your-api-key-here"
 LANGSMITH_PROJECT="Inbox0"

--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,6 @@ LANGSMITH_TRACING="true"
 LANGSMITH_ENDPOINT="https://api.smith.langchain.com"
 LANGSMITH_API_KEY="lsv2_your-api-key-here"
 LANGSMITH_PROJECT="Inbox0"
+
+#Shadow Mode
+SHADOW_MODE=false

--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -33,10 +33,6 @@ class Agent:
         self.client = OpenAI(
             api_key=schema.api_key,
             base_url=schema.base_url,
-            default_headers={
-                "HTTP-Referer": schema.site_url,
-                "X-Title": schema.app_name,
-            },
         )
         self._setup_function_map()
 
@@ -84,6 +80,12 @@ class Agent:
     )
     def _create_chat_completion(self, **kwargs) -> ChatCompletion:
         """Retry transient OpenAI/OpenRouter-compatible completion failures."""
+        # enforce zdr for OpenRouter
+        if "openrouter.ai" in (self.schema.base_url or ""):
+            kwargs.setdefault("extra_body", {})
+            provider = kwargs["extra_body"].setdefault("provider", {})
+            provider.update({"zdr": True, "data_collection": "deny"})
+
         return self.client.chat.completions.create(**kwargs)
 
     def _timed_completion(self, label: str, **kwargs) -> ChatCompletion:

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -74,3 +74,37 @@ class TestAgent(unittest.TestCase):
 
         self.assertEqual(result, expected_response)
         self.assertEqual(create.call_count, 2)
+
+    def test_openrouter_chat_completion_privacy(self):
+        """OpenRouter requests require ZDR and deny provider data collection."""
+        self.agent.schema.base_url = "https://openrouter.ai/api/v1"
+        self.agent.client = MagicMock()
+        expected_response = MagicMock()
+        expected_response = self.agent.client.chat.completions.create.return_value
+
+        messages = [{"role": "user", "content": "hello"}]
+        result = self.agent._create_chat_completion(model="test-model", messages=messages)
+
+        self.assertEqual(result, expected_response)
+
+        create_completion = self.agent.client.chat.completions.create
+
+        create_completion.assert_called_once_with(
+            model="test-model",
+            messages=messages,
+            extra_body={
+                "provider": {
+                    "zdr": True,
+                    "data_collection": "deny",
+                }
+            },
+        )
+
+    def test_non_openrouter_chat_completion_omits_openrouter_fields(self):
+        """Non-OpenRouter requests do not receive OpenRouter-specific fields"""
+        self.agent.schema.base_url = "http://localhost:11434/v1"
+        self.agent.client = MagicMock()
+        messages = [{"role": "user", "content": "hello"}]
+        self.agent._create_chat_completion(model="test-model", messages=messages)
+        create_completion = self.agent.client.chat.completions.create
+        create_completion.assert_called_once_with(model="test-model", messages=messages)


### PR DESCRIPTION
#### Reference Issues/PRs
None.

#### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Maintenance / cleanup
- [ ] Test-only change
- [ ] Breaking change
- [ ] Documentation only

#### What does this implement/fix? Explain your changes.
Enforces Zero Data Retention and denies provider data collection for OpenRouter requests. Removes optional OpenRouter attribution headers while keeping non-OpenRouter providers unaffected.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Confirm OpenRouter requests receive the privacy fields.
- Confirm other OpenAI-compatible providers remain unaffected.

#### Did you add any tests for the change?
Yes. Tests verify OpenRouter privacy parameters are included and omitted for non-OpenRouter endpoints.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [SEC], or [BREAKING]
    - [BUG] - bugfix
    - [MNT] - CI, test framework, dependency updates
    - [ENH] - adding or improving code
    - [DOC] - writing or improving documentation or docstrings
    - [SEC] - security fixes or vulnerability patches
    - [BREAKING] - any change that requires user to update their setup or code
- [x] Tests added or updated for changed behavior, or explained why not needed
- [x] No secrets, credentials, or `.env` values committed
- [x] `pyproject.toml` updated if new dependencies were added and `uv.lock` regenerated via `uv sync`